### PR TITLE
docs: MVP PRD, 구현 문서, todo 체크리스트 추가

### DIFF
--- a/docs/start/1_mvp_implementation.md
+++ b/docs/start/1_mvp_implementation.md
@@ -1,0 +1,509 @@
+# MVP 구현 문서: IntelliJ Markdown WYSIWYG Editor Plugin
+
+## 1. 프로젝트 초기 셋업
+
+### 1.1 Gradle 프로젝트 구조
+
+```
+intellij-plugin-markdown-editor/
+├── build.gradle.kts
+├── settings.gradle.kts
+├── gradle.properties
+├── gradle/
+│   └── wrapper/
+├── src/
+│   ├── main/
+│   │   ├── kotlin/
+│   │   │   └── com/github/kenshin579/markdowneditor/
+│   │   │       ├── editor/
+│   │   │       │   ├── MarkdownEditorProvider.kt
+│   │   │       │   ├── MarkdownFileEditor.kt
+│   │   │       │   └── MarkdownHtmlPanel.kt
+│   │   │       ├── controller/
+│   │   │       │   ├── PreviewStaticServer.kt
+│   │   │       │   ├── MarkdownFileController.kt
+│   │   │       │   └── ImageUploadController.kt
+│   │   │       ├── model/
+│   │   │       │   └── MarkdownResponse.kt
+│   │   │       ├── service/
+│   │   │       │   └── EditorSettingsService.kt
+│   │   │       └── listener/
+│   │   │           └── JcefSupportCheck.kt
+│   │   └── resources/
+│   │       ├── META-INF/
+│   │       │   └── plugin.xml
+│   │       ├── template/
+│   │       │   └── editor.html
+│   │       └── vditor/           ← 번들링된 Vditor 라이브러리
+│   │           ├── dist/
+│   │           └── ...
+│   └── test/
+│       └── kotlin/
+│           └── com/github/kenshin579/markdowneditor/
+├── docs/
+└── CLAUDE.md
+```
+
+### 1.2 build.gradle.kts 핵심 설정
+
+```kotlin
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.9.25"
+    id("org.jetbrains.intellij.platform") version "2.2.1"
+}
+
+group = "com.github.kenshin579"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity("2024.2")
+        bundledPlugin("com.intellij.java")
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        id = "com.github.kenshin579.markdown-editor"
+        name = "Markdown WYSIWYG Editor"
+        version = project.version.toString()
+        ideaVersion {
+            sinceBuild = "242"    // 2024.2
+            untilBuild = provider { null }
+        }
+    }
+}
+```
+
+### 1.3 plugin.xml
+
+```xml
+<idea-plugin>
+    <id>com.github.kenshin579.markdown-editor</id>
+    <name>Markdown WYSIWYG Editor</name>
+    <vendor>kenshin579</vendor>
+
+    <depends>com.intellij.modules.platform</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- 커스텀 에디터 -->
+        <fileEditorProvider
+            implementation="com.github.kenshin579.markdowneditor.editor.MarkdownEditorProvider"/>
+
+        <!-- 내장 HTTP 서버 핸들러 -->
+        <httpRequestHandler
+            implementation="com.github.kenshin579.markdowneditor.controller.PreviewStaticServer"/>
+
+        <!-- JCEF 지원 확인 -->
+        <postStartupActivity
+            implementation="com.github.kenshin579.markdowneditor.listener.JcefSupportCheck"/>
+
+        <!-- 설정 -->
+        <applicationService
+            serviceImplementation="com.github.kenshin579.markdowneditor.service.EditorSettingsService"/>
+    </extensions>
+</idea-plugin>
+```
+
+## 2. 핵심 컴포넌트 구현
+
+### 2.1 MarkdownEditorProvider
+
+`.md` 파일을 열 때 커스텀 WYSIWYG 에디터 탭을 등록하는 `FileEditorProvider`.
+
+```kotlin
+class MarkdownEditorProvider : FileEditorProvider {
+    override fun accept(project: Project, file: VirtualFile): Boolean {
+        // .md 파일이고 JCEF 지원하는 경우만 활성화
+        return file.extension == "md" && JBCefApp.isSupported()
+    }
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+        return MarkdownFileEditor(project, file)
+    }
+
+    override fun getEditorTypeId(): String = "markdown-wysiwyg-editor"
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.PLACE_AFTER_DEFAULT_EDITOR
+}
+```
+
+- `PLACE_AFTER_DEFAULT_EDITOR`: 기본 Markdown 플러그인 에디터 뒤에 탭 추가 (공존)
+- JCEF 미지원 IDE에서는 탭 자체가 나타나지 않음
+
+### 2.2 MarkdownFileEditor
+
+`FileEditor` 구현체. JCEF 브라우저 패널을 생성하고 관리한다.
+
+```kotlin
+class MarkdownFileEditor(
+    private val project: Project,
+    private val file: VirtualFile
+) : UserDataHolderBase(), FileEditor {
+
+    private val panel: MarkdownHtmlPanel = MarkdownHtmlPanel(project, file)
+
+    override fun getComponent(): JComponent = panel.component
+    override fun getPreferredFocusedComponent(): JComponent = panel.component
+    override fun getName(): String = "Markdown Editor"
+
+    // 파일 변경 감지 → 에디터 동기화
+    override fun isModified(): Boolean = false  // HTTP 기반 저장이므로 IDE 관리 불필요
+
+    override fun dispose() {
+        panel.dispose()
+    }
+}
+```
+
+### 2.3 MarkdownHtmlPanel (JCEF 브라우저)
+
+`JCEFHtmlPanel`을 확장하여 Vditor 에디터를 로드하는 핵심 컴포넌트.
+
+**주요 구현 사항:**
+
+1. **HTML 템플릿 로드**: `template/editor.html`을 로드하고 변수 치환
+2. **JS ↔ Kotlin 브릿지**: `JBCefJSQuery`로 양방향 통신
+3. **IDE 테마 연동**: `EditorColorsManager` 리스너로 Dark/Light 전환 감지
+4. **클립보드 통합**: IDE의 Copy/Paste 동작을 JCEF 브라우저와 연결
+5. **컨텍스트 메뉴**: 우클릭 메뉴를 IDE 스타일로 오버라이드
+
+```kotlin
+class MarkdownHtmlPanel(
+    private val project: Project,
+    private val file: VirtualFile
+) : JCEFHtmlPanel(null) {
+
+    private val jsQuery = JBCefJSQuery.create(this as JBCefBrowser)
+
+    init {
+        // JS → Kotlin 콜백 등록
+        jsQuery.addHandler { request ->
+            handleJsRequest(request)
+            null
+        }
+
+        // HTML 템플릿 로드
+        val html = loadTemplate()
+        loadHTML(html)
+    }
+
+    private fun loadTemplate(): String {
+        val template = ResourceUtil.getResource(
+            javaClass.classLoader, "template", "editor.html"
+        ).readText()
+
+        val isDark = EditorColorsManager.getInstance().isDarkEditor
+        return template
+            .replace("{{filePath}}", file.path)
+            .replace("{{darcula}}", isDark.toString())
+            .replace("{{serverUrl}}", getServerUrl())
+    }
+}
+```
+
+### 2.4 PreviewStaticServer (HTTP 요청 핸들러)
+
+IntelliJ 내장 HTTP 서버(`HttpRequestHandler`)를 확장하여 에디터의 API 엔드포인트를 제공한다.
+
+```kotlin
+class PreviewStaticServer : HttpRequestHandler() {
+
+    override fun isAccessible(request: HttpRequest): Boolean {
+        return request.uri().startsWith(PREFIX)
+    }
+
+    override fun process(
+        urlDecoder: QueryStringDecoder,
+        request: FullHttpRequest,
+        context: ChannelHandlerContext
+    ): Boolean {
+        val path = urlDecoder.path().removePrefix(PREFIX)
+        return when {
+            path.startsWith("api/file") -> MarkdownFileController.handle(urlDecoder, request, context)
+            path.startsWith("api/upload") -> ImageUploadController.handle(urlDecoder, request, context)
+            path.startsWith("resources/") -> ResourcesController.handle(urlDecoder, request, context)
+            else -> false
+        }
+    }
+
+    companion object {
+        const val PREFIX = "/markdown-editor/"
+    }
+}
+```
+
+### 2.5 MarkdownFileController
+
+마크다운 파일 읽기/쓰기 API.
+
+```kotlin
+object MarkdownFileController {
+    // GET: 파일 내용 읽기
+    fun readFile(file: VirtualFile): String {
+        return ReadAction.compute<String, Throwable> {
+            FileDocumentManager.getInstance()
+                .getDocument(file)?.text ?: ""
+        }
+    }
+
+    // POST: 파일 내용 저장
+    fun writeFile(file: VirtualFile, content: String) {
+        ApplicationManager.getApplication().invokeLaterOnWriteThread {
+            WriteCommandAction.runWriteCommandAction(project) {
+                val document = FileDocumentManager.getInstance().getDocument(file)
+                document?.setText(content)
+            }
+        }
+    }
+}
+```
+
+**스레딩 규칙:**
+- 읽기: `ReadAction.compute` (read lock)
+- 쓰기: `invokeLaterOnWriteThread` + `WriteCommandAction` (write lock + undo 지원)
+
+## 3. Vditor 통합
+
+### 3.1 번들링
+
+Vditor JS/CSS 파일을 플러그인 리소스에 포함하여 오프라인 동작을 보장한다.
+
+```
+src/main/resources/vditor/
+├── dist/
+│   ├── index.min.js
+│   ├── index.css
+│   └── js/
+│       ├── highlight.js/
+│       ├── katex/
+│       ├── mermaid/
+│       └── ...
+```
+
+`ResourcesController`가 `/resources/vditor/**` 경로로 정적 파일을 서빙한다.
+
+### 3.2 editor.html 템플릿
+
+JCEF에 로드되는 메인 HTML. Vditor 초기화와 IDE 연동 로직을 포함한다.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="{{serverUrl}}/resources/vditor/dist/index.css"/>
+    <style>
+        /* IDE 테마 연동 스타일 */
+        body { background: {{bgColor}}; color: {{fgColor}}; }
+    </style>
+</head>
+<body>
+    <div id="vditor"></div>
+
+    <script src="{{serverUrl}}/resources/vditor/dist/index.min.js"></script>
+    <script>
+        const vditor = new Vditor('vditor', {
+            mode: 'wysiwyg',        // 라이브 렌더링 모드
+            value: '',               // initValue()에서 로드
+            cache: { enable: false },
+            toolbar: [...],
+
+            input(value) {
+                // 내용 변경 시 저장 트리거
+                markDirty();
+            },
+            blur(value) {
+                // 포커스 아웃 시 자동 저장
+                saveToFile(value);
+            },
+            after() {
+                // 초기화 완료 → 파일 내용 로드
+                initValue();
+            }
+        });
+
+        // IDE에서 파일 내용 로드
+        async function initValue() {
+            const resp = await fetch('{{serverUrl}}/api/file/read?path={{filePath}}');
+            const data = await resp.json();
+            vditor.setValue(data.content);
+        }
+
+        // 파일 저장
+        async function saveToFile(content) {
+            await fetch('{{serverUrl}}/api/file/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path: '{{filePath}}', content: content })
+            });
+        }
+    </script>
+</body>
+</html>
+```
+
+### 3.3 Vditor 모드 전환
+
+| Vditor 모드 | PRD 뷰 모드 | 설정값 |
+|-------------|-------------|--------|
+| `wysiwyg` | 라이브 렌더링 (기본) | `mode: 'wysiwyg'` |
+| `ir` (Instant Rendering) | - (미사용) | - |
+| `sv` (Split View) | 소스 모드 | `mode: 'sv'` 에서 프리뷰 숨김 처리 |
+
+소스 모드 전환은 `vditor.switchMode('sv')` 호출 후 프리뷰 패널을 CSS로 숨겨 순수 소스 편집만 노출한다.
+또는 Vditor API의 `getValue()`로 소스를 추출하여 별도 텍스트 에디터 패널에 표시하는 방식도 가능하다.
+
+## 4. Slash 커맨드 구현
+
+### 4.1 Vditor 힌트 시스템 활용
+
+Vditor에는 `hint` 옵션이 내장되어 있어, `/` 입력 시 커스텀 팝업을 표시할 수 있다.
+
+```javascript
+const vditor = new Vditor('vditor', {
+    hint: {
+        // '/' 입력 시 커맨드 목록 반환
+        extend: [
+            {
+                key: '/',
+                hint(key) {
+                    // key = '/' 이후 입력 문자열 (필터용)
+                    return filterCommands(key);
+                }
+            }
+        ]
+    }
+});
+
+function filterCommands(query) {
+    const commands = [
+        // Basic Blocks
+        { value: '#',       html: '<b>H1</b> Heading 1' },
+        { value: '##',      html: '<b>H2</b> Heading 2' },
+        { value: '###',     html: '<b>H3</b> Heading 3' },
+        { value: '- ',      html: '<b>Bullet</b> Bulleted list' },
+        { value: '1. ',     html: '<b>Num</b> Numbered list' },
+        { value: '- [ ] ',  html: '<b>Todo</b> Checklist' },
+        { value: '> ',      html: '<b>Quote</b> Quote block' },
+        { value: '---\n',   html: '<b>Div</b> Divider' },
+        // Media
+        { value: '```\n',   html: '<b>Code</b> Code block' },
+        // ... 기타 커맨드
+    ];
+
+    return commands.filter(cmd =>
+        cmd.html.toLowerCase().includes(query.toLowerCase())
+    );
+}
+```
+
+### 4.2 커스텀 Slash 커맨드 (Vditor 힌트 한계 시)
+
+Vditor 힌트로 카테고리 그룹핑이 부족하면, `/` 키 입력을 인터셉트하여 커스텀 HTML 팝업을 직접 구현한다.
+
+```javascript
+// 커스텀 슬래시 메뉴
+document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && isLineStart()) {
+        e.preventDefault();
+        showSlashMenu(getCursorPosition());
+    }
+});
+
+function showSlashMenu(position) {
+    const menu = document.getElementById('slash-menu');
+    menu.style.left = position.x + 'px';
+    menu.style.top = position.y + 'px';
+    menu.style.display = 'block';
+    // 카테고리별 렌더링, 키보드 네비게이션 등
+}
+```
+
+## 5. 이미지 삽입
+
+### 5.1 ImageUploadController
+
+```kotlin
+object ImageUploadController {
+    fun handle(request: FullHttpRequest, project: Project, basePath: String): UploadResponse {
+        // 1. 멀티파트 요청에서 이미지 데이터 추출
+        // 2. 프로젝트 기준 상대 경로에 파일 저장
+        // 3. 마크다운 이미지 경로 반환 (상대 경로)
+        val relativePath = saveImage(imageData, project, basePath)
+        return UploadResponse(
+            succMap = mapOf(fileName to relativePath)
+        )
+    }
+}
+```
+
+### 5.2 Vditor 업로드 설정
+
+```javascript
+const vditor = new Vditor('vditor', {
+    upload: {
+        url: '{{serverUrl}}/api/upload?project={{projectPath}}&filePath={{filePath}}',
+        accept: 'image/*',
+        handler(files) {
+            // 파일 업로드 후 마크다운 이미지 삽입
+        }
+    }
+});
+```
+
+## 6. IDE 테마 연동
+
+### 6.1 Dark/Light 모드 감지
+
+```kotlin
+// MarkdownFileEditor 초기화 시
+EditorColorsManager.getInstance().addEditorColorsListener({ scheme ->
+    val isDark = ColorUtil.isDark(scheme.defaultBackground)
+    // JS 함수 호출로 Vditor 테마 전환
+    panel.executeJavaScript("switchTheme($isDark)")
+}, this)
+```
+
+### 6.2 JS 테마 전환
+
+```javascript
+function switchTheme(isDark) {
+    vditor.setTheme(
+        isDark ? 'dark' : 'classic',        // 에디터 테마
+        isDark ? 'dark' : 'light',           // 콘텐츠 테마
+        isDark ? 'native' : 'github'         // 코드 하이라이트 테마
+    );
+}
+```
+
+## 7. JCEF 지원 확인
+
+```kotlin
+class JcefSupportCheck : StartupActivity {
+    override fun runActivity(project: Project) {
+        if (!JBCefApp.isSupported()) {
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("Markdown Editor")
+                .createNotification(
+                    "Markdown WYSIWYG Editor requires JCEF support.",
+                    NotificationType.WARNING
+                )
+                .notify(project)
+        }
+    }
+}
+```

--- a/docs/start/1_mvp_prd.md
+++ b/docs/start/1_mvp_prd.md
@@ -1,0 +1,389 @@
+# MVP PRD: IntelliJ Markdown WYSIWYG Editor Plugin
+
+## 1. 개요
+
+### 1.1 프로젝트 정보
+
+| 항목 | 내용 |
+|------|------|
+| 프로젝트명 | IntelliJ Markdown WYSIWYG Editor |
+| 저장소 | https://github.com/kenshin579/intellij-plugin-markdown-editor |
+| 플랫폼 | JetBrains IntelliJ Platform (모든 JetBrains IDE 지원) |
+| 언어 | Kotlin |
+| 최소 IDE 버전 | 2024.2+ (JDK 21 필수) |
+
+### 1.2 비전
+
+> Typora처럼 마크다운 에디터인지 모르는 편집기
+
+마크다운 문법이 보이지 않는 **완전한 WYSIWYG 경험**을 JetBrains IDE 안에서 제공한다.
+사용자가 `#`, `**`, `` ``` `` 같은 마크다운 문법을 입력하면 즉시 렌더링된 형태로 전환되어,
+마크다운을 모르는 사용자도 자연스럽게 사용할 수 있는 에디터를 목표로 한다.
+
+### 1.3 참고 프로젝트
+
+| 프로젝트 | 설명 | 참고 포인트 |
+|-----------|------|-------------|
+| [Typora](https://typora.io/) | 데스크톱 WYSIWYG 마크다운 에디터 | UX 벤치마크 - 실시간 렌더링, Focus/Typewriter 모드 |
+| [shuzijun/markdown-editor](https://github.com/shuzijun/markdown-editor) | IntelliJ 마크다운 에디터 플러그인 | 기술 아키텍처 참고 - JCEF + Vditor 기반 |
+
+---
+
+## 2. 핵심 요구사항
+
+### 2.1 뷰 모드
+
+| 모드 | 설명 | 우선순위 |
+|------|------|----------|
+| **라이브 렌더링 (기본)** | 마크다운 문법 입력 즉시 렌더링. 모든 블록이 항상 렌더링된 상태로 표시 | **P0** |
+| **소스 모드** | 순수 마크다운 텍스트 편집 모드 | **P0** |
+
+- 에디터 하단 탭 또는 툴바 버튼으로 모드 전환
+- 기본 모드는 **라이브 렌더링**으로 설정
+
+### 2.2 Slash 커맨드 (Notion 스타일)
+
+Notion과 동일하게, `/`를 입력하면 **커맨드 팔레트**가 표시되고 카테고리별로 블록을 삽입할 수 있다.
+
+> **참고**: Notion Slash 커맨드 — https://www.notion.com/help/keyboard-shortcuts
+
+#### 2.2.1 UX 동작
+
+- `/` 입력 시 **카테고리별 그룹화된 드롭다운 팝업** 표시
+- 타이핑으로 필터링 (예: `/h` → 제목 관련 커맨드만 표시)
+- 키보드 `↑↓`로 탐색, `Enter`로 선택, `Esc`로 취소
+- 마크다운 문법 직접 입력도 동일하게 동작 (예: `# ` 입력 → 제목 스타일로 전환)
+- 빈 줄뿐 아니라 **줄 시작 위치 어디서든** `/` 입력으로 호출 가능
+
+#### 2.2.2 Basic Blocks
+
+| 커맨드 | Notion 동일 | 동작 | 우선순위 |
+|--------|:-----------:|------|----------|
+| `/text` 또는 `/plain` | Y | 일반 텍스트 블록 생성 | **P0** |
+| `/h1` 또는 `/#` | Y | 대제목 (H1) | **P0** |
+| `/h2` 또는 `/##` | Y | 중제목 (H2) | **P0** |
+| `/h3` 또는 `/###` | Y | 소제목 (H3) | **P0** |
+| `/bullet` | Y | 비순서 목록 | **P0** |
+| `/num` | Y | 순서 목록 | **P0** |
+| `/todo` | Y | 체크리스트 (체크박스) | **P0** |
+| `/toggle` | Y | 토글 리스트 (접기/펼치기) | P1 |
+| `/quote` | Y | 인용 블록 | **P0** |
+| `/div` | Y | 구분선 (`---`) | **P0** |
+| `/link` | Y | 다른 문서 링크 | P2 |
+
+#### 2.2.3 Inline
+
+| 커맨드 | Notion 동일 | 동작 | 우선순위 |
+|--------|:-----------:|------|----------|
+| `/equation` | Y | 인라인 LaTeX 수식 (`$...$`) | P1 |
+| `/emoji` | Y | 이모지 선택 팝업 | P2 |
+
+#### 2.2.4 Media
+
+| 커맨드 | Notion 동일 | 동작 | 우선순위 |
+|--------|:-----------:|------|----------|
+| `/image` | Y | 이미지 삽입 (업로드/경로 지정) | **P0** |
+| `/code` | Y | 코드 블록 (언어 선택 드롭다운) | **P0** |
+| `/table` | - | 표 삽입 (행/열 지정 다이얼로그) | **P0** |
+
+#### 2.2.5 Advanced
+
+| 커맨드 | Notion 동일 | 동작 | 우선순위 |
+|--------|:-----------:|------|----------|
+| `/math` 또는 `/latex` | Y | LaTeX 수식 블록 (`$$...$$`) | P1 |
+| `/mermaid` | - | Mermaid 다이어그램 블록 | P1 |
+| `/toc` | Y | 목차 (Table of Contents) 자동 생성 | P1 |
+| `/duplicate` | Y | 현재 블록 복제 | P2 |
+| `/delete` | Y | 현재 블록 삭제 | P2 |
+
+#### 2.2.6 Turn Into (블록 변환)
+
+Notion의 `/turn` 커맨드와 동일하게, 기존 블록을 다른 타입으로 변환한다.
+
+| 커맨드 | 동작 | 우선순위 |
+|--------|------|----------|
+| `/turntext` | 일반 텍스트로 변환 | P2 |
+| `/turnh1` ~ `/turnh3` | 제목으로 변환 | P2 |
+| `/turnbullet` | 비순서 목록으로 변환 | P2 |
+| `/turnnum` | 순서 목록으로 변환 | P2 |
+| `/turntodo` | 체크리스트로 변환 | P2 |
+| `/turnquote` | 인용으로 변환 | P2 |
+| `/turncode` | 코드 블록으로 변환 | P2 |
+
+#### 2.2.7 커맨드 팔레트 UI
+
+```
+┌─────────────────────────────────┐
+│  / h                       ✕   │  ← 입력 필터
+├─────────────────────────────────┤
+│  BASIC BLOCKS                   │  ← 카테고리 헤더
+│  ┌───┐                          │
+│  │ H1│  Heading 1         /#    │  ← 아이콘 + 이름 + 단축키
+│  └───┘                          │
+│  ┌───┐                          │
+│  │ H2│  Heading 2         /##   │
+│  └───┘                          │
+│  ┌───┐                          │
+│  │ H3│  Heading 3         /###  │
+│  └───┘                          │
+├─────────────────────────────────┤
+│  MEDIA                          │
+│  ...                            │
+└─────────────────────────────────┘
+```
+
+- 각 항목: **아이콘 + 커맨드명 + 설명 + 키보드 단축키**
+- 카테고리별 그룹화 (Basic, Inline, Media, Advanced)
+- 현재 입력에 따른 실시간 필터링
+
+### 2.3 마크다운 요소 지원
+
+#### 2.3.1 기본 텍스트 서식 (P0)
+
+| 요소 | 마크다운 문법 | 렌더링 동작 |
+|------|---------------|-------------|
+| 제목 (H1~H6) | `# ~ ######` | 입력 즉시 제목 스타일 적용 |
+| 볼드 | `**text**` | 굵은 글씨로 표시 |
+| 이탤릭 | `*text*` | 기울임 글씨로 표시 |
+| 취소선 | `~~text~~` | 취소선 표시 |
+| 인라인 코드 | `` `code` `` | 코드 스타일 표시 |
+| 링크 | `[text](url)` | 클릭 가능한 링크 표시 |
+| 인용 | `> text` | 인용 블록 스타일 |
+| 구분선 | `---` | 수평선 렌더링 |
+| 목록 | `- `, `1. ` | 들여쓰기 목록 |
+
+#### 2.3.2 체크리스트 (P0)
+
+```markdown
+- [ ] 미완료 항목
+- [x] 완료 항목
+```
+
+- 체크박스 클릭으로 상태 토글
+- 마크다운 소스 자동 동기화 (`[ ]` <-> `[x]`)
+
+#### 2.3.3 코드 블록 (P0)
+
+````markdown
+```python
+def hello():
+    print("Hello, World!")
+```
+````
+
+- **Syntax Highlighting**: 주요 언어 지원 (Python, Java, Kotlin, JavaScript, TypeScript, Go, Rust, SQL, YAML, JSON, Bash 등)
+- 언어 선택 드롭다운
+- 줄 번호 표시 (옵션)
+
+#### 2.3.4 표 (P0)
+
+```markdown
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+```
+
+- 비주얼 테이블 편집 (셀 클릭으로 편집)
+- 행/열 추가/삭제 (컨텍스트 메뉴 또는 버튼)
+- 드래그로 열 너비 조정
+
+#### 2.3.5 이미지 삽입 (P0)
+
+| 방법 | 설명 |
+|------|------|
+| 드래그 & 드롭 | 파일을 에디터에 드롭 |
+| 클립보드 붙여넣기 | 스크린샷 Ctrl+V 삽입 |
+| Slash 커맨드 | `/image`로 파일 선택 다이얼로그 |
+| 마크다운 문법 | `![alt](path)` 직접 입력 |
+
+- 이미지는 프로젝트 내 상대 경로로 저장
+- 인라인 프리뷰 렌더링
+- 이미지 리사이즈 지원 (드래그)
+
+#### 2.3.6 수식 - LaTeX (P1)
+
+**인라인 수식**: `$E = mc^2$`
+**블록 수식**:
+```markdown
+$$
+\sum_{i=1}^{n} x_i = x_1 + x_2 + \cdots + x_n
+$$
+```
+
+- KaTeX 또는 MathJax 기반 렌더링
+- 실시간 프리뷰
+
+#### 2.3.7 다이어그램 - Mermaid (P1)
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[OK]
+    B -->|No| D[Cancel]
+```
+````
+
+- Mermaid.js 기반 렌더링
+- 지원 다이어그램: Flowchart, Sequence, Gantt, Class, State, Pie, ER
+
+---
+
+## 3. 기술 아키텍처
+
+### 3.1 아키텍처 개요
+
+```
+┌─────────────────────────────────────────────┐
+│              JetBrains IDE                   │
+│  ┌───────────────────────────────────────┐   │
+│  │      FileEditorProvider (Kotlin)      │   │
+│  │  - .md 파일 감지 및 에디터 탭 등록      │   │
+│  └──────────────┬────────────────────────┘   │
+│                 │                             │
+│  ┌──────────────▼────────────────────────┐   │
+│  │        JCEF Browser Panel             │   │
+│  │  ┌─────────────────────────────────┐  │   │
+│  │  │   Web-based WYSIWYG Editor      │  │   │
+│  │  │   (Vditor / Milkdown / Custom)  │  │   │
+│  │  │                                 │  │   │
+│  │  │  - 라이브 렌더링                  │  │   │
+│  │  │  - Slash 커맨드 UI               │  │   │
+│  │  │  - Mermaid / KaTeX 렌더링        │  │   │
+│  │  └─────────────────────────────────┘  │   │
+│  └──────────────┬────────────────────────┘   │
+│                 │ JS ↔ Kotlin Bridge          │
+│  ┌──────────────▼────────────────────────┐   │
+│  │      Backend Controllers (Kotlin)     │   │
+│  │  - 파일 읽기/쓰기                      │   │
+│  │  - 이미지 업로드                       │   │
+│  │  - 설정 관리                           │   │
+│  └───────────────────────────────────────┘   │
+└─────────────────────────────────────────────┘
+```
+
+### 3.2 기술 스택
+
+| 계층 | 기술 | 설명 |
+|------|------|------|
+| JDK | **JDK 21** | IntelliJ 2024.2+ 필수 (JetBrains Runtime 21 기반) |
+| Plugin Framework | IntelliJ Platform SDK | FileEditorProvider, Actions, Services |
+| 언어 | Kotlin | 플러그인 코드 전체 |
+| 빌드 | Gradle + IntelliJ Platform Plugin | 빌드, 테스트, 패키징 |
+| 브라우저 엔진 | JCEF (Chromium Embedded Framework) | 웹 기반 에디터 렌더링 |
+| 에디터 라이브러리 | **후보 평가 필요** (아래 참조) | WYSIWYG 마크다운 에디터 |
+| 다이어그램 | Mermaid.js | 다이어그램 렌더링 |
+| 수식 | KaTeX | LaTeX 수식 렌더링 |
+| Syntax Highlight | highlight.js / Prism.js | 코드 블록 하이라이팅 |
+
+### 3.3 개발 환경 설정 (macOS)
+
+#### 3.3.1 JDK 버전 요구사항
+
+| IntelliJ Platform 버전 | 필요 JDK |
+|------------------------|----------|
+| 2024.1 | Java 17 |
+| **2024.2 ~ 2025.x** | **Java 21** |
+
+본 프로젝트는 **2024.2+** 를 타겟하므로 **JDK 21**이 필요하다.
+
+#### 3.3.2 JDK 설치 (macOS — Homebrew)
+
+```bash
+# OpenJDK 21 설치
+brew install openjdk@21
+
+# 시스템 Java로 등록 (Apple Silicon Mac)
+sudo ln -sfn /opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk \
+  /Library/Java/JavaVirtualMachines/openjdk-21.jdk
+
+# JAVA_HOME 설정 (~/.zshrc에 추가)
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+
+# 확인
+java -version
+echo $JAVA_HOME
+```
+
+#### 3.3.3 Gradle 설정
+
+프로젝트의 `build.gradle.kts`에서 JDK 21을 사용하도록 설정:
+
+```kotlin
+kotlin {
+    jvmToolchain(21)
+}
+```
+
+### 3.4 에디터 라이브러리 후보
+
+| 라이브러리 | 장점 | 단점 |
+|-----------|------|------|
+| [Vditor](https://github.com/Vanessa219/vditor) | 참고 프로젝트에서 검증됨, WYSIWYG/IR/SV 3모드, Mermaid/KaTeX 내장 | 중국어 중심 커뮤니티, 커스터마이징 제약 |
+| [Milkdown](https://milkdown.dev/) | Plugin 시스템, ProseMirror 기반, Slash 커맨드 내장, 높은 커스터마이징 | 비교적 복잡한 설정 |
+| [Tiptap](https://tiptap.dev/) | ProseMirror 기반, 확장성 우수, 활발한 커뮤니티 | 마크다운 전용이 아님 (확장 필요) |
+| [ByteMD](https://github.com/bytedance/bytemd) | 경량, 플러그인 시스템 | WYSIWYG 미지원 (split view만) |
+
+**MVP 권장**: Vditor (참고 프로젝트에서 검증된 JCEF 통합 방식 활용 가능)
+
+### 3.5 핵심 컴포넌트
+
+| 컴포넌트 | 역할 |
+|---------|------|
+| `MarkdownEditorProvider` | `.md` 파일 열 때 커스텀 에디터 탭 제공 |
+| `MarkdownEditorPanel` | JCEF 브라우저를 감싸는 Swing 패널 |
+| `MarkdownFileController` | 파일 읽기/쓰기 API (IntelliJ Document API 사용) |
+| `ImageUploadController` | 이미지 업로드 및 경로 처리 |
+| `EditorSettingsService` | 뷰 모드, 테마 등 사용자 설정 관리 |
+| `template/editor.html` | JCEF에 로드되는 에디터 HTML (JS 라이브러리 포함) |
+
+### 3.6 데이터 흐름
+
+```
+[사용자 편집] → Vditor (JS) → editBlur/editInput 이벤트
+    → HTTP POST /api/file/save → MarkdownFileController
+    → IntelliJ Document API → 파일 시스템 (.md)
+
+[파일 열기] → MarkdownEditorProvider → JCEF 패널 생성
+    → editor.html 로드 → HTTP GET /api/file/read
+    → MarkdownFileController → Document 내용 반환
+    → Vditor 초기화 (마크다운 렌더링)
+```
+
+---
+
+## 4. MVP 스코프
+
+| Phase | 내용 | 우선순위 |
+|-------|------|----------|
+| **Phase 1** | 기초 인프라 — 프로젝트 셋업, JCEF 에디터, Vditor 번들링, 파일 I/O, 테마 연동 | **P0** |
+| **Phase 2** | 핵심 편집 — 뷰 모드 (라이브/소스), 기본 서식, 목록, 체크리스트, 코드 블록, 표 | **P0** |
+| **Phase 3** | 미디어 & 슬래시 — 이미지 삽입, Slash 커맨드 UI, Basic/Media 커맨드 | **P0** |
+| **Phase 4** | 고급 렌더링 — LaTeX, Mermaid, Advanced/Inline 커맨드 | P1 |
+| **Phase 5** | 완성도 — Turn Into, 설정 UI, 아웃라인, Export, Focus 모드, Marketplace 배포 | P2 |
+
+> 상세 체크리스트는 `1_mvp_todo.md` 참조
+
+---
+
+## 5. 비기능 요구사항
+
+| 항목 | 요구사항 |
+|------|---------|
+| IDE 호환성 | IntelliJ IDEA, WebStorm, PyCharm, GoLand 등 JetBrains 2024.2+ |
+| JCEF 필수 | 플러그인 로드 시 JCEF 지원 여부 확인, 미지원 시 안내 메시지 |
+| 성능 | 1MB 이하 마크다운 파일 편집 시 입력 지연 없음 (< 100ms) |
+| 동기화 | 에디터 내용과 실제 `.md` 파일이 항상 일치 |
+| 공존 | JetBrains 기본 Markdown 플러그인과 충돌 없이 공존 (에디터 탭 추가 방식) |
+| 오프라인 | 에디터 라이브러리를 플러그인에 번들링하여 네트워크 없이 동작 |
+
+---
+
+## 6. 성공 지표
+
+| 지표 | 목표 |
+|------|------|
+| MVP 완성 | Phase 1~3 기능 동작 확인 |
+| 기본 워크플로우 | `.md` 파일 열기 → WYSIWYG 편집 → 저장 → 소스 확인 시 올바른 마크다운 |
+| Slash 커맨드 | `/` 입력 → 요소 선택 → 즉시 렌더링 동작 확인 |
+| 마크다운 호환성 | CommonMark + GFM (GitHub Flavored Markdown) 스펙 준수 |

--- a/docs/start/1_mvp_todo.md
+++ b/docs/start/1_mvp_todo.md
@@ -1,0 +1,176 @@
+# MVP Todo: IntelliJ Markdown WYSIWYG Editor Plugin
+
+> PRD: `1_mvp_prd.md` | 구현: `1_mvp_implementation.md`
+
+---
+
+## Phase 1: 기초 인프라 (P0)
+
+### 1-1. 프로젝트 셋업
+- [ ] JDK 21 설치 확인 (`java -version`)
+- [ ] Gradle + IntelliJ Platform Plugin 2.x 프로젝트 생성
+- [ ] `build.gradle.kts` 작성 (intellijIdeaCommunity 2024.2, Kotlin, jvmToolchain 21)
+- [ ] `settings.gradle.kts` 작성
+- [ ] `gradle.properties` 작성 (플러그인 메타데이터)
+- [ ] `.gitignore` 작성 (IntelliJ + Gradle 패턴)
+- [ ] `./gradlew build` 성공 확인
+
+### 1-2. plugin.xml 등록
+- [ ] `src/main/resources/META-INF/plugin.xml` 작성
+- [ ] `fileEditorProvider` 확장 등록 (`MarkdownEditorProvider`)
+- [ ] `httpRequestHandler` 확장 등록 (`PreviewStaticServer`)
+- [ ] `postStartupActivity` 확장 등록 (`JcefSupportCheck`)
+- [ ] `applicationService` 확장 등록 (`EditorSettingsService`)
+
+### 1-3. JCEF 에디터 기본 뼈대
+- [ ] `MarkdownEditorProvider.kt` 구현 (.md 파일 감지, JCEF 지원 확인)
+- [ ] `MarkdownFileEditor.kt` 구현 (FileEditor 인터페이스)
+- [ ] `MarkdownHtmlPanel.kt` 구현 (JCEFHtmlPanel 확장)
+- [ ] JCEF 패널에 "Hello World" HTML 로드 확인
+- [ ] `./gradlew runIde` 로 IDE 실행 → .md 파일 열기 → 커스텀 에디터 탭 표시 확인
+
+### 1-4. Vditor 번들링
+- [ ] Vditor 라이브러리 다운로드 (dist 폴더)
+- [ ] `src/main/resources/vditor/` 에 번들링
+- [ ] `ResourcesController.kt` 구현 (정적 파일 서빙)
+- [ ] `template/editor.html` 작성 (Vditor 초기화)
+- [ ] JCEF에서 Vditor 에디터 로드 확인 (빈 에디터 표시)
+
+### 1-5. 파일 읽기/쓰기 연동
+- [ ] `PreviewStaticServer.kt` 구현 (HTTP 라우팅)
+- [ ] `MarkdownFileController.kt` 구현 (GET: 읽기, POST: 쓰기)
+- [ ] editor.html에서 파일 내용 로드 (`initValue()`)
+- [ ] 에디터 blur 시 파일 저장 (`saveToFile()`)
+- [ ] .md 파일 열기 → Vditor에 내용 표시 → 편집 → 저장 → 소스 확인 워크플로우 동작 확인
+
+### 1-6. IDE 테마 연동
+- [ ] `EditorColorsManager` 리스너로 Dark/Light 감지
+- [ ] MarkdownHtmlPanel 초기화 시 현재 테마 반영
+- [ ] JS `switchTheme()` 함수로 Vditor 테마 전환
+- [ ] IDE 테마 변경 시 에디터 즉시 반영 확인
+
+---
+
+## Phase 2: 핵심 편집 기능 (P0)
+
+### 2-1. 뷰 모드
+- [ ] 라이브 렌더링 모드 (Vditor `wysiwyg` 모드) — 기본값
+- [ ] 소스 모드 구현 (Vditor `sv` 모드 또는 별도 텍스트 패널)
+- [ ] 에디터 하단 또는 툴바에 모드 전환 버튼 추가
+- [ ] 모드 전환 시 내용 동기화 확인
+
+### 2-2. 기본 마크다운 요소 렌더링
+- [ ] 제목 (H1~H6): `#` 입력 즉시 렌더링
+- [ ] 볼드 (`**text**`), 이탤릭 (`*text*`), 취소선 (`~~text~~`)
+- [ ] 인라인 코드 (`` `code` ``)
+- [ ] 링크 (`[text](url)`) — 클릭 시 브라우저 오픈
+- [ ] 인용 블록 (`> text`)
+- [ ] 구분선 (`---`)
+- [ ] 비순서 목록 (`- `)
+- [ ] 순서 목록 (`1. `)
+
+### 2-3. 체크리스트
+- [ ] `- [ ]`, `- [x]` 렌더링
+- [ ] 체크박스 클릭 → 마크다운 소스 자동 토글 (`[ ]` ↔ `[x]`)
+
+### 2-4. 코드 블록
+- [ ] ` ``` ` 입력 시 코드 블록 생성
+- [ ] Syntax Highlighting 동작 확인 (Python, Java, Kotlin, JS, Go 등)
+- [ ] 언어 선택 드롭다운
+
+### 2-5. 표
+- [ ] 마크다운 표 렌더링
+- [ ] 셀 클릭으로 비주얼 편집
+- [ ] 행/열 추가/삭제 (컨텍스트 메뉴 또는 버튼)
+
+---
+
+## Phase 3: 미디어 & 슬래시 (P0)
+
+### 3-1. 이미지 삽입
+- [ ] `ImageUploadController.kt` 구현
+- [ ] Vditor upload 옵션 설정 (API 엔드포인트 연결)
+- [ ] 드래그 & 드롭으로 이미지 삽입
+- [ ] 클립보드 붙여넣기 (Ctrl+V / Cmd+V)로 이미지 삽입
+- [ ] `/image` Slash 커맨드로 파일 선택 다이얼로그
+- [ ] 이미지 상대 경로 저장 확인
+- [ ] 인라인 이미지 프리뷰 렌더링
+
+### 3-2. Slash 커맨드 팝업 UI
+- [ ] `/` 입력 감지 → 드롭다운 팝업 표시
+- [ ] 카테고리별 그룹화 (Basic Blocks, Media)
+- [ ] 타이핑으로 필터링 (예: `/h` → 제목 관련만)
+- [ ] 키보드 `↑↓` 탐색, `Enter` 선택, `Esc` 취소
+- [ ] 아이콘 + 커맨드명 + 설명 표시
+
+### 3-3. Basic Blocks 커맨드
+- [ ] `/text` 또는 `/plain` → 일반 텍스트 블록
+- [ ] `/h1` 또는 `/#` → H1 제목
+- [ ] `/h2` 또는 `/##` → H2 제목
+- [ ] `/h3` 또는 `/###` → H3 제목
+- [ ] `/bullet` → 비순서 목록
+- [ ] `/num` → 순서 목록
+- [ ] `/todo` → 체크리스트
+- [ ] `/quote` → 인용 블록
+- [ ] `/div` → 구분선
+
+### 3-4. Media 커맨드
+- [ ] `/image` → 이미지 삽입
+- [ ] `/code` → 코드 블록 (언어 선택)
+- [ ] `/table` → 표 삽입 (행/열 지정)
+
+---
+
+## Phase 4: 고급 렌더링 (P1)
+
+### 4-1. LaTeX 수식
+- [ ] KaTeX 번들링 (Vditor 내장 활용)
+- [ ] 인라인 수식 (`$...$`) 렌더링
+- [ ] 블록 수식 (`$$...$$`) 렌더링
+- [ ] `/equation` Slash 커맨드 (인라인)
+- [ ] `/math` 또는 `/latex` Slash 커맨드 (블록)
+
+### 4-2. Mermaid 다이어그램
+- [ ] Mermaid.js 번들링 (Vditor 내장 활용)
+- [ ] ` ```mermaid ` 코드 블록 → 다이어그램 렌더링
+- [ ] `/mermaid` Slash 커맨드
+- [ ] Flowchart, Sequence, Gantt 등 주요 다이어그램 동작 확인
+
+### 4-3. 추가 커맨드
+- [ ] `/toc` → 목차 자동 생성
+- [ ] `/toggle` → 토글 리스트 (접기/펼치기)
+
+---
+
+## Phase 5: 완성도 (P2)
+
+### 5-1. Turn Into 커맨드
+- [ ] `/turntext` → 일반 텍스트로 변환
+- [ ] `/turnh1` ~ `/turnh3` → 제목으로 변환
+- [ ] `/turnbullet` → 비순서 목록으로 변환
+- [ ] `/turnnum` → 순서 목록으로 변환
+- [ ] `/turntodo` → 체크리스트로 변환
+- [ ] `/turnquote` → 인용으로 변환
+- [ ] `/turncode` → 코드 블록으로 변환
+
+### 5-2. 추가 기능
+- [ ] `/duplicate` → 현재 블록 복제
+- [ ] `/delete` → 현재 블록 삭제
+- [ ] `/emoji` → 이모지 선택 팝업
+
+### 5-3. 설정 & UI
+- [ ] 에디터 설정 UI (Settings → Tools → Markdown WYSIWYG Editor)
+- [ ] 아웃라인 패널 (목차 기반 네비게이션)
+
+### 5-4. Export
+- [ ] HTML Export
+- [ ] PDF Export
+
+### 5-5. 고급 UX
+- [ ] Focus 모드 (현재 블록 외 흐리게)
+- [ ] Typewriter 모드 (커서 항상 화면 중앙)
+
+### 5-6. 배포
+- [ ] JetBrains Marketplace 플러그인 등록
+- [ ] GitHub Actions CI/CD 파이프라인 구성
+- [ ] CHANGELOG.md 작성


### PR DESCRIPTION
## Summary
- Typora 스타일 WYSIWYG 마크다운 에디터 플러그인의 MVP 문서 작성
- `1_mvp_prd.md`: 요구사항 (비전, 뷰 모드, Notion 스타일 Slash 커맨드, 마크다운 요소, 기술 아키텍처, macOS JDK 설치)
- `1_mvp_implementation.md`: 구현 상세 (프로젝트 구조, JCEF+Vditor 통합, 핵심 컴포넌트 코드)
- `1_mvp_todo.md`: Phase 1~5 단계별 체크리스트

## Test plan
- [ ] 각 문서 마크다운 렌더링 확인
- [ ] 문서 간 상호 참조 링크 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)