### PR TITLE
chore: 프로젝트 이름을 Markora로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-IntelliJ Platform plugin for Markdown editing. The project is in early development.
+Markora - Typora-like WYSIWYG Markdown editor plugin for JetBrains IDEs. The project is in early development.
 
 - **Repository**: https://github.com/kenshin579/intellij-plugin-markdown-editor
-- **Language**: Kotlin (expected)
+- **Language**: Kotlin
 - **Build System**: Gradle with IntelliJ Platform Plugin
 
 ## Build Commands

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,8 @@ configurations {
 
 intellijPlatform {
     pluginConfiguration {
-        id = "com.github.kenshin579.markdown-editor"
-        name = "Markdown WYSIWYG Editor"
+        id = "com.github.kenshin579.markora"
+        name = "Markora"
         version = project.version.toString()
         ideaVersion {
             sinceBuild = "242"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # IntelliJ Platform Plugin
-pluginGroup = com.github.kenshin579.markdowneditor
-pluginName = Markdown WYSIWYG Editor
+pluginGroup = com.github.kenshin579.markora
+pluginName = Markora
 pluginVersion = 0.1.0
 
 # IntelliJ Platform

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,4 +3,4 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
-rootProject.name = "intellij-plugin-markdown-editor"
+rootProject.name = "markora"

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/ExportController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/ExportController.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.diagnostic.logger
 import io.netty.buffer.Unpooled

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/ImageUploadController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/ImageUploadController.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.diagnostic.logger
 import io.netty.buffer.Unpooled

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/LocalImageController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/LocalImageController.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.diagnostic.logger
 import io.netty.buffer.Unpooled

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/MarkdownFileController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/MarkdownFileController.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/PreviewStaticServer.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/PreviewStaticServer.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.diagnostic.logger
 import io.netty.channel.ChannelHandlerContext
@@ -44,7 +44,7 @@ class PreviewStaticServer : HttpRequestHandler() {
     }
 
     companion object {
-        const val PREFIX = "/markdown-editor/"
+        const val PREFIX = "/markora/"
         private val LOG = logger<PreviewStaticServer>()
 
         fun getServiceUrl(): String {

--- a/src/main/kotlin/com/github/kenshin579/markora/controller/ResourcesController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/ResourcesController.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.controller
+package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.diagnostic.logger
 import io.netty.buffer.Unpooled

--- a/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownEditorProvider.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownEditorProvider.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.editor
+package com.github.kenshin579.markora.editor
 
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
@@ -23,6 +23,6 @@ class MarkdownEditorProvider : FileEditorProvider, DumbAware {
     override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.PLACE_AFTER_DEFAULT_EDITOR
 
     companion object {
-        const val EDITOR_TYPE_ID = "markdown-wysiwyg-editor"
+        const val EDITOR_TYPE_ID = "markora-editor"
     }
 }

--- a/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownFileEditor.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownFileEditor.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.editor
+package com.github.kenshin579.markora.editor
 
 import com.intellij.openapi.editor.colors.EditorColorsListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -34,7 +34,7 @@ class MarkdownFileEditor(
 
     override fun getPreferredFocusedComponent(): JComponent = panel.component
 
-    override fun getName(): String = "Markdown Editor"
+    override fun getName(): String = "Markora"
 
     override fun getFile(): VirtualFile = file
 

--- a/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownHtmlPanel.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownHtmlPanel.kt
@@ -1,6 +1,6 @@
-package com.github.kenshin579.markdowneditor.editor
+package com.github.kenshin579.markora.editor
 
-import com.github.kenshin579.markdowneditor.controller.PreviewStaticServer
+import com.github.kenshin579.markora.controller.PreviewStaticServer
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger

--- a/src/main/kotlin/com/github/kenshin579/markora/listener/JcefSupportCheck.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/listener/JcefSupportCheck.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.listener
+package com.github.kenshin579.markora.listener
 
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -11,9 +11,9 @@ class JcefSupportCheck : ProjectActivity {
     override suspend fun execute(project: Project) {
         if (!JBCefApp.isSupported()) {
             NotificationGroupManager.getInstance()
-                .getNotificationGroup("Markdown Editor Notifications")
+                .getNotificationGroup("Markora Notifications")
                 .createNotification(
-                    "Markdown WYSIWYG Editor",
+                    "Markora",
                     "This plugin requires JCEF support. Please use a JetBrains IDE with bundled JCEF.",
                     NotificationType.WARNING
                 )

--- a/src/main/kotlin/com/github/kenshin579/markora/service/EditorSettingsService.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/service/EditorSettingsService.kt
@@ -1,4 +1,4 @@
-package com.github.kenshin579.markdowneditor.service
+package com.github.kenshin579.markora.service
 
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
@@ -6,7 +6,7 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 
 @Service(Service.Level.APP)
-@State(name = "MarkdownEditorSettings", storages = [Storage("markdown-wysiwyg-editor.xml")])
+@State(name = "MarkoraSettings", storages = [Storage("markora.xml")])
 class EditorSettingsService : PersistentStateComponent<EditorSettingsService.State> {
 
     data class State(

--- a/src/main/kotlin/com/github/kenshin579/markora/settings/MarkdownEditorConfigurable.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/settings/MarkdownEditorConfigurable.kt
@@ -1,6 +1,6 @@
-package com.github.kenshin579.markdowneditor.settings
+package com.github.kenshin579.markora.settings
 
-import com.github.kenshin579.markdowneditor.service.EditorSettingsService
+import com.github.kenshin579.markora.service.EditorSettingsService
 import com.intellij.openapi.options.Configurable
 import javax.swing.*
 
@@ -13,7 +13,7 @@ class MarkdownEditorConfigurable : Configurable {
     private var fontSizeSpinner: JSpinner? = null
     private var autoSaveSpinner: JSpinner? = null
 
-    override fun getDisplayName(): String = "Markdown WYSIWYG Editor"
+    override fun getDisplayName(): String = "Markora"
 
     override fun createComponent(): JComponent {
         val settings = EditorSettingsService.getInstance().state

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,37 +1,37 @@
 <idea-plugin>
-    <id>com.github.kenshin579.markdown-editor</id>
-    <name>Markdown WYSIWYG Editor</name>
+    <id>com.github.kenshin579.markora</id>
+    <name>Markora</name>
     <vendor>kenshin579</vendor>
     <description>Typora-like WYSIWYG Markdown editor for JetBrains IDEs</description>
 
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Custom Markdown WYSIWYG Editor -->
+        <!-- Markora Editor -->
         <fileEditorProvider
-            implementation="com.github.kenshin579.markdowneditor.editor.MarkdownEditorProvider"/>
+            implementation="com.github.kenshin579.markora.editor.MarkdownEditorProvider"/>
 
         <!-- HTTP Request Handler for Vditor resources and file API -->
         <httpRequestHandler
-            implementation="com.github.kenshin579.markdowneditor.controller.PreviewStaticServer"/>
+            implementation="com.github.kenshin579.markora.controller.PreviewStaticServer"/>
 
         <!-- JCEF Support Check on Startup -->
         <postStartupActivity
-            implementation="com.github.kenshin579.markdowneditor.listener.JcefSupportCheck"/>
+            implementation="com.github.kenshin579.markora.listener.JcefSupportCheck"/>
 
         <!-- Editor Settings -->
         <applicationService
-            serviceImplementation="com.github.kenshin579.markdowneditor.service.EditorSettingsService"/>
+            serviceImplementation="com.github.kenshin579.markora.service.EditorSettingsService"/>
 
         <!-- Settings UI -->
         <applicationConfigurable
             parentId="tools"
-            instance="com.github.kenshin579.markdowneditor.settings.MarkdownEditorConfigurable"
-            id="com.github.kenshin579.markdowneditor.settings"
-            displayName="Markdown WYSIWYG Editor"/>
+            instance="com.github.kenshin579.markora.settings.MarkdownEditorConfigurable"
+            id="com.github.kenshin579.markora.settings"
+            displayName="Markora"/>
 
         <!-- Notification Group -->
-        <notificationGroup id="Markdown Editor Notifications"
+        <notificationGroup id="Markora Notifications"
                            displayType="BALLOON"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Summary
- 패키지명 `com.github.kenshin579.markdowneditor` → `com.github.kenshin579.markora`로 변경
- 플러그인 ID `com.github.kenshin579.markdown-editor` → `com.github.kenshin579.markora`로 변경
- 플러그인 표시명 `Markdown WYSIWYG Editor` → `Markora`로 통일
- 에디터 타입 ID, HTTP prefix, 설정 저장소, 알림 그룹 등 내부 식별자 일괄 변경
- 빌드 설정 파일 (build.gradle.kts, settings.gradle.kts, gradle.properties) 업데이트

## Test plan
- [x] `./gradlew build` 빌드 성공 확인
- [ ] `./gradlew runIde`로 플러그인 정상 로드 확인
- [ ] Settings > Tools > Markora 설정 UI 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)