### PR TITLE
feat: prepare plugin for JetBrains Marketplace listing

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,31 @@
 <idea-plugin>
     <id>com.github.kenshin579.markora</id>
     <name>Markora</name>
-    <vendor>kenshin579</vendor>
-    <description>Typora-like WYSIWYG Markdown editor for JetBrains IDEs</description>
+    <vendor url="https://markora.advenoh.pe.kr">kenshin579</vendor>
+    <description><![CDATA[
+        <p><b>Markora</b> brings Notion-style WYSIWYG Markdown editing to JetBrains IDEs.
+        Edit Markdown files in a block editor that renders as you type — no preview pane needed.</p>
+
+        <p><b>Features</b></p>
+        <ul>
+          <li>BlockNote-based block editor with slash commands</li>
+          <li>LaTeX math (KaTeX) and Mermaid diagrams render inline</li>
+          <li>Debounced auto-save to standard CommonMark + GFM Markdown</li>
+          <li>Image drag/drop and clipboard paste auto-organized into <code>images/</code></li>
+          <li>Light/Dark theme synced with the IDE</li>
+          <li>External links open in your system browser — won't break IDE flow</li>
+        </ul>
+
+        <p><b>Compatibility</b></p>
+        <p>Works on IntelliJ IDEA, WebStorm, PyCharm, GoLand, RubyMine, PhpStorm, Rider, CLion
+        2024.2 or newer (with JCEF enabled, which is the default).</p>
+
+        <p><b>Links</b></p>
+        <ul>
+          <li><a href="https://markora.advenoh.pe.kr">Website</a></li>
+          <li><a href="https://github.com/kenshin579/markora">GitHub</a></li>
+        </ul>
+    ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
 

--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect width="40" height="40" rx="8" fill="#2563eb"/>
+  <text x="20" y="28" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="26" font-weight="700" fill="#fff">M</text>
+</svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect width="40" height="40" rx="8" fill="#60a5fa"/>
+  <text x="20" y="28" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="26" font-weight="700" fill="#fff">M</text>
+</svg>


### PR DESCRIPTION
## Summary

JetBrains Marketplace 첫 등록을 위한 메타데이터 + 아이콘 보강.

- **plugin.xml description 보강**: 한 줄짜리 description을 HTML CDATA 블록으로 교체 — 기능 리스트, 호환 IDE, 사이트/GitHub 링크 포함. Marketplace 카드 + IDE 내 Plugins 설정 화면에서 노출됨
- **`<vendor url>` 추가**: 벤더 옆에 사이트 링크 표시
- **`pluginIcon.svg` (40×40, light)** + **`pluginIcon_dark.svg`**: Marketplace 카드/IDE Plugins UI용 아이콘. markora.advenoh.pe.kr 사이트의 favicon과 동일 디자인 (파란 배경 + 흰 "M")

## Test plan

- [x] `./gradlew buildPlugin` 통과 → `build/distributions/markora-0.1.0.zip` (~3.8MB)
- [x] 산출물에 plugin.xml + 아이콘 포함 확인
- [ ] **사용자 직접**: zip을 https://plugins.jetbrains.com 에 업로드 + 메타 입력 + 검토 제출

## 등록 절차 (사용자 직접 진행)

1. https://plugins.jetbrains.com 로그인
2. **Upload Plugin** → `build/distributions/markora-0.1.0.zip`
3. Marketplace UI에서 추가 입력:
   - **Category**: Editors / Markdown
   - **Tags**: `markdown`, `wysiwyg`, `editor`, `katex`, `mermaid`
   - **Screenshots**: 1–8장 (디자인 사이트 hero / 실제 plugin 동작 캡처)
   - **Documentation URL**: `https://markora.advenoh.pe.kr`
   - **Source URL**: `https://github.com/kenshin579/markora`
   - **License**: MIT
4. **Submit for review** → JetBrains 검토 (첫 등록 24~48h)

## 후속 작업 (별도 PR)

- **`verifyPlugin` 정밀 설정**: `pluginVerification.ides`에 명시적 stable IDE list (recommended()는 EAP `261.x` dependency를 못 받아서 fail). 이 PR에선 일시 추가 후 제거 — JetBrains의 자체 검증으로 첫 등록 충분
- **GitHub Actions tag 자동 출시**: `release.yml`을 tag → version 동기화 + verifyPlugin + publishPlugin로 확장
- **markora.advenoh.pe.kr `lib/site-config.ts`의 `marketplace` URL** 채우기 → 사이트 CTA 자동 활성화