### PR TITLE
feat: switch to gradient brand icon

### DIFF
--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <rect width="40" height="40" rx="8" fill="#2563eb"/>
-  <text x="20" y="28" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="26" font-weight="700" fill="#fff">M</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <rect width="80" height="80" rx="16" fill="url(#g)"/>
+  <g fill="#fff">
+    <g opacity="0.65">
+      <rect x="14" y="28" width="3" height="24" rx="1"/>
+      <rect x="22" y="28" width="3" height="24" rx="1"/>
+      <rect x="10" y="34" width="19" height="3" rx="1"/>
+      <rect x="10" y="44" width="19" height="3" rx="1"/>
+    </g>
+    <path d="M 34 26 L 40 26 L 47 42 L 54 26 L 60 26 L 60 58 L 55 58 L 55 36 L 49 50 L 46 50 L 40 36 L 40 58 L 34 58 Z"/>
+  </g>
 </svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <rect width="40" height="40" rx="8" fill="#60a5fa"/>
-  <text x="20" y="28" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="26" font-weight="700" fill="#fff">M</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="80" height="80" rx="16" fill="url(#g)"/>
+  <g fill="#fff">
+    <g opacity="0.7">
+      <rect x="14" y="28" width="3" height="24" rx="1"/>
+      <rect x="22" y="28" width="3" height="24" rx="1"/>
+      <rect x="10" y="34" width="19" height="3" rx="1"/>
+      <rect x="10" y="44" width="19" height="3" rx="1"/>
+    </g>
+    <path d="M 34 26 L 40 26 L 47 42 L 54 26 L 60 26 L 60 58 L 55 58 L 55 36 L 49 50 L 46 50 L 40 36 L 40 58 L 34 58 Z"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary

플러그인 아이콘을 brand 탐색에서 결정된 **D1f Gradient (#M 레이아웃)** 으로 교체.

- **pluginIcon.svg** (light IDE): `#2563eb` → `#7c3aed` 그라디언트
- **pluginIcon_dark.svg** (dark IDE): `#60a5fa` → `#a78bfa` 그라디언트 (lighter, dark 배경 가독성)

`#` 글리프는 markdown heading 마커, 큰 `M`은 brand letter. 두 글리프 모두 SVG path라 폰트 의존성 없음.

## Brand 탐색 요약

8개 후보(M↓ / Block / M+slash / #M / Two-tone / M+cursor / Page+M)를 비교 → **#M 레이아웃** 채택 → **gradient 톤** 채택. Modern dev tool brand 톤(Linear/Stripe vibe)으로 Marketplace 카드에서 다른 markdown 플러그인과 시각 차별.

## Test plan

- [x] light/dark 두 SVG 모두 16/24/40/80/160px에서 식별 가능
- [x] 다크 IDE 배경(시뮬)에서 dark variant 가독성 OK
- [ ] **사용자 직접**: `./gradlew runIde`로 sandbox IDE 띄워 Settings → Plugins에서 실제 카드 확인 (light + dark)
- [ ] (다음 빌드부터) Marketplace 카드 56px 미리보기 — `./gradlew buildPlugin` 후 [Markora 검증 페이지](https://plugins.jetbrains.com/intellij-plugin-verifier) 또는 등록 시 미리보기

## 후속

- markora.advenoh.pe.kr 사이트 `public/favicon.svg`도 동일 디자인으로 교체 (별도 PR)
- (선택) 사이트 헤더의 `mk-logo-mark` CSS도 그라디언트 + #M로 매칭 — 별도 PR