### PR TITLE
docs: mark Marketplace install path as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ For the full list of standard blocks, see [BlockNote documentation](https://www.
 
 ## Installation
 
-### From JetBrains Marketplace (Coming Soon)
+### From JetBrains Marketplace
 
-1. Open **Settings** > **Plugins** > **Marketplace**
+1. Open **Settings** > **Plugins** > **Marketplace** (or visit the [Marketplace listing](https://plugins.jetbrains.com/plugin/31598-markora) directly)
 2. Search for **Markora**
 3. Click **Install** and restart your IDE
 


### PR DESCRIPTION
## Summary
- README의 "From JetBrains Marketplace (Coming Soon)" → "From JetBrains Marketplace"
- 설치 단계에 Marketplace listing 직접 링크 추가

## Why
플러그인 publish 완료 (https://plugins.jetbrains.com/plugin/31598-markora). 사이트의 Install CTA 활성화와 일관성 맞춤.

## Test plan
- [ ] `grep -ic "coming soon" README.md` → 0
- [ ] GitHub renderer에서 Marketplace 링크 클릭 동작 확인

## Related Spec
`markora.advenoh.pe.kr/docs/superpowers/specs/2026-05-06-marketplace-publish-sync-design.md`