### PR TITLE
docs: replace stale intellij-plugin-markdown-editor slug with markora

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Markora - Typora-like WYSIWYG Markdown editor plugin for JetBrains IDEs. The project is in early development.
 
-- **Repository**: https://github.com/kenshin579/intellij-plugin-markdown-editor
+- **Repository**: https://github.com/kenshin579/markora
 - **Language**: Kotlin
 - **Build System**: Gradle with IntelliJ Platform Plugin
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For the full list of standard blocks, see [BlockNote documentation](https://www.
 
 ### Manual Installation
 
-1. Download the latest release from [GitHub Releases](https://github.com/kenshin579/intellij-plugin-markdown-editor/releases)
+1. Download the latest release from [GitHub Releases](https://github.com/kenshin579/markora/releases)
 2. Open **Settings** > **Plugins** > **Gear icon** > **Install Plugin from Disk...**
 3. Select the downloaded `.zip` file and restart your IDE
 
@@ -67,8 +67,8 @@ Configure the plugin at **Settings** > **Tools** > **Markora**:
 
 ```bash
 # Clone the repository
-git clone https://github.com/kenshin579/intellij-plugin-markdown-editor.git
-cd intellij-plugin-markdown-editor
+git clone https://github.com/kenshin579/markora.git
+cd markora
 
 # First build downloads Node 20.18.0 to .gradle/nodejs/ (managed by gradle-node-plugin).
 # No system Node required.


### PR DESCRIPTION
## Summary
- README의 GitHub Releases 링크, git clone URL, cd 명령을 새 repo 이름(`markora`)으로 갱신
- CLAUDE.md의 Repository 포인터도 동일하게 갱신
- 결과: `grep "intellij-plugin-markdown-editor" README.md CLAUDE.md` → 0건

## Why
GitHub repo가 `kenshin579/intellij-plugin-markdown-editor` → `kenshin579/markora`로 rename됨. GitHub redirect로 계속 동작하지만 docs는 canonical URL을 사용하는 게 일관성 있음.

## Test plan
- [x] `grep -c "intellij-plugin-markdown-editor" README.md CLAUDE.md` → 0
- [x] `file -I` → UTF-8

## Related
Marketplace publish sync 시리즈의 follow-up cleanup. PR #19 머지 후 발견된 추가 stale URL 정리.