### PR TITLE
docs: refresh CHANGELOG for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,33 @@
 # Changelog
 
+All notable changes to Markora are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-09
+
 ### Added
-- WYSIWYG Markdown editor using Vditor in JCEF browser
-- Source mode toggle (WYSIWYG / Source)
+- Code block syntax highlighting via shiki with lazy-loaded language/theme chunks
+  - 23 curated languages: JavaScript, TypeScript, JSX, TSX, Java, Kotlin, Python, Go, Rust, C, C++, Shell, JSON, YAML, HTML, CSS, SCSS, SQL, XML, Markdown, Dockerfile, Properties, Plain Text
+  - Light theme `github-light` and dark theme `one-dark-pro`, synced to the IDE theme via CSS variables (no editor reload on toggle)
+  - Language picker (`<select>` in the code block) is always visible with theme-aware contrast
+  - Language alias normalization on load (`bash` → `shellscript`, `kt` → `kotlin`, `js` → `javascript`, etc.) so the picker shows the correct label when authors write the alias in markdown
+- Tag-triggered automated release pipeline (`make release VERSION=x.y.z`) — `release.yml` workflow builds the plugin and attaches the `.zip` to the GitHub Release on `v*` tag push
+
+### Fixed
+- BlockNote's hardcoded `codeBlock` dark background (`#161616` / `#fff`) is now overridden per IDE theme so the code block matches editor surroundings in both light and dark modes
+
+## [0.1.0]
+
+Initial JetBrains Marketplace release.
+
+### Added
+- WYSIWYG Markdown editor (BlockNote, Notion-style block editor) embedded in JCEF Chromium browser
 - IDE Dark/Light theme synchronization
-- Auto-save with debounce (1s delay)
-- External file change detection on focus
-- Image upload via drag & drop, clipboard paste
-- Slash commands (`/h1`~`/h6`, `/bullet`, `/num`, `/todo`, `/quote`, `/div`, `/code`, `/table`, `/image`)
-- LaTeX math rendering (KaTeX) - inline `$...$` and block `$$...$$`
+- Auto-save with 1-second debounce and external file change detection on focus
+- Image upload via drag & drop and clipboard paste
+- LaTeX math (KaTeX): block (`$$...$$`) and inline (`$...$`)
 - Mermaid diagram rendering
-- Math slash commands (`/equation`, `/math`)
-- Mermaid slash command (`/mermaid`)
-- Table of contents (`/toc`)
-- Emoji support with `:emoji:` syntax
-- Settings UI (Settings > Tools > Markdown WYSIWYG Editor)
-- Outline panel (via Vditor toolbar)
-- HTML export
-- GitHub Actions CI/CD pipeline
-- External link handling (opens in system browser)
-- Code block syntax highlighting with line numbers
+- BlockNote slash menu with custom Math (block + inline) and Mermaid commands
+- Settings UI (Settings → Tools → Markora) with persisted preferences
+- Plugin icons (light / dark) and JetBrains Marketplace listing


### PR DESCRIPTION
## Summary
- 기존 `[Unreleased]` 섹션이 **Vditor 시절** 항목(Source mode toggle, `/h1`~`/h6` 등 Vditor 슬래시 명령, `/toc`, HTML export 등)을 그대로 들고 있어 BlockNote 마이그레이션(PR #15) 이후 상태와 어긋난 상황을 정리
- `[0.1.0]` — 현재 JetBrains Marketplace에 published된 BlockNote 베이스라인 (auto-save, KaTeX, Mermaid, BlockNote slash menu, Settings UI 등)
- `[0.2.0]` — 이번 릴리스 (syntax highlighting + tag-triggered release 자동화 + BlockNote 하드코딩 배경 오버라이드 fix)
- Keep a Changelog / SemVer 헤더 명시

## Why
릴리스 직전 정합성 정리. README의 release 섹션이 "ensure CHANGELOG.md has the unreleased changes documented"라고 안내하므로 `make release VERSION=0.2.0` 직전에 단독 PR로 정돈.

## Test plan
- [x] CHANGELOG.md가 UTF-8 (`file -I`)
- [x] 렌더링 시 0.2.0 / 0.1.0 섹션이 의도대로 분리됨
- [ ] 리뷰어 확인: 0.1.0에 남긴 항목이 실제 마켓플레이스 published 버전과 일치하는지
- [ ] 0.2.0 항목이 main의 실제 변경사항(PR #21, #22)과 일치하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)