### PR TITLE
ci: grant contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `release.yml`의 release job에 `permissions: contents: write` 추가
- v0.2.0 릴리스에서 발견된 [Resource not accessible by integration](https://github.com/kenshin579/markora/actions/runs/25602455071/job/75158604827) 오류 수정

## Background
v0.2.0 릴리스 시 워크플로우가 다음 단계에서 실패:
```
Found release v0.2.0 (with id=319944262)
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v0.2.0:
HttpError: Resource not accessible by integration
```

GitHub Actions의 기본 `GITHUB_TOKEN` 권한이 read-only로 제한되어 있어 `softprops/action-gh-release@v2`가:
- 기존 릴리스에 `.zip` asset 업로드 (`PATCH /repos/.../releases/{id}/assets`)
- `generate_release_notes: true`로 release notes 생성 (`POST /repos/.../releases/generate-notes`)

이 두 호출 모두 `contents: write` 권한이 필요한데 명시되지 않아 실패.

## Recovery
이 PR이 merge된 후 v0.2.0 릴리스 복구:
1. 실패한 워크플로우 재실행: `gh run rerun 25602455071` (또는 GitHub Actions UI에서 "Re-run failed jobs")
2. asset(`.zip`)이 https://github.com/kenshin579/markora/releases/tag/v0.2.0 에 첨부되는지 확인

## Test plan
- [x] yaml 문법 정상 (`permissions:` 블록 위치는 job 레벨)
- [ ] merge 후 v0.2.0 워크플로우 재실행 → asset 첨부 성공
- [ ] 향후 `make release VERSION=x.y.z` 시 워크플로우가 한 번에 성공하는지 (다음 릴리스에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)