### PR TITLE
fix: 편집 시 마크다운 라운드트립 데이터 손실 방지

### DIFF
--- a/frontend/src/bridge/__tests__/imageMap.test.ts
+++ b/frontend/src/bridge/__tests__/imageMap.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { collectImageUrlMap, restoreImagePaths } from '../imageMap';
+
+const BASE = 'http://localhost:63342/markora/';
+
+describe('collectImageUrlMap', () => {
+  it('상대경로 이미지를 base 기준 절대 URL로 매핑 (절대→원본)', () => {
+    const md = '![alt](images/foo.png)\n\ntext\n';
+    const map = collectImageUrlMap(md, BASE);
+    expect(map.get('http://localhost:63342/markora/images/foo.png')).toBe('images/foo.png');
+  });
+
+  it('./ 와 ../ 상대경로도 매핑', () => {
+    const md = '![a](./a.png) ![b](../b.png)';
+    const map = collectImageUrlMap(md, BASE);
+    expect(map.get('http://localhost:63342/markora/a.png')).toBe('./a.png');
+    expect(map.get('http://localhost:63342/b.png')).toBe('../b.png');
+  });
+
+  it('이미 절대 URL(http/https)인 이미지는 매핑하지 않는다', () => {
+    const md = '![x](https://example.com/x.png)';
+    const map = collectImageUrlMap(md, BASE);
+    expect(map.size).toBe(0);
+  });
+
+  it('타이틀이 있어도 경로만 추출', () => {
+    const md = '![a](images/foo.png "caption")';
+    const map = collectImageUrlMap(md, BASE);
+    expect(map.get('http://localhost:63342/markora/images/foo.png')).toBe('images/foo.png');
+  });
+
+  it('이미지가 없으면 빈 맵', () => {
+    expect(collectImageUrlMap('# no images', BASE).size).toBe(0);
+  });
+});
+
+describe('restoreImagePaths', () => {
+  it('직렬화된 절대 URL을 원본 상대경로로 되돌린다', () => {
+    const map = new Map([['http://localhost:63342/markora/images/foo.png', 'images/foo.png']]);
+    const md = '![alt](http://localhost:63342/markora/images/foo.png)\n';
+    expect(restoreImagePaths(md, map)).toBe('![alt](images/foo.png)\n');
+  });
+
+  it('타이틀은 보존', () => {
+    const map = new Map([['http://localhost:63342/markora/images/foo.png', 'images/foo.png']]);
+    const md = '![alt](http://localhost:63342/markora/images/foo.png "cap")\n';
+    expect(restoreImagePaths(md, map)).toBe('![alt](images/foo.png "cap")\n');
+  });
+
+  it('맵에 없는 URL은 그대로 둔다', () => {
+    const map = new Map([['http://localhost:63342/markora/images/foo.png', 'images/foo.png']]);
+    const md = '![x](https://cdn.example.com/y.png)\n';
+    expect(restoreImagePaths(md, map)).toBe(md);
+  });
+
+  it('빈 맵이면 원본 그대로', () => {
+    const md = '![x](http://localhost:63342/markora/images/foo.png)';
+    expect(restoreImagePaths(md, new Map())).toBe(md);
+  });
+
+  it('업로드 이미지의 local-image API URL도 역변환', () => {
+    const url = 'http://localhost:63342/api/local-image?path=%2Ftmp%2Fimages%2Fa.png';
+    const map = new Map([[url, 'images/a.png']]);
+    const md = `![](${url})`;
+    expect(restoreImagePaths(md, map)).toBe('![](images/a.png)');
+  });
+});

--- a/frontend/src/bridge/__tests__/markora.test.ts
+++ b/frontend/src/bridge/__tests__/markora.test.ts
@@ -55,6 +55,36 @@ describe('createBridge (real fetch)', () => {
     expect(JSON.parse(call[1].body)).toEqual({ path: '/tmp/x.md', content: '# updated' });
   });
 
+  it('frontmatter를 본문에서 떼어 반환하고 저장 시 다시 붙인다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '---\ntitle: Post\n---\n\n# Body\n' }),
+    });
+    const b = createBridge(ctx);
+    const body = await b.loadFile();
+    expect(body).toBe('\n# Body\n'); // frontmatter 제거됨
+    await b.saveFile('\n# Body edited\n');
+    const saveCall = (globalThis.fetch as any).mock.calls.find(
+      (c: any[]) => c[0] === 'http://localhost:9000/api/file/save'
+    );
+    expect(JSON.parse(saveCall[1].body).content).toBe('---\ntitle: Post\n---\n\n# Body edited\n');
+  });
+
+  it('로드한 상대경로 이미지는 저장 시 절대 URL이 아닌 원본 상대경로로 기록된다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '![alt](images/foo.png)\n' }),
+    });
+    const b = createBridge(ctx);
+    await b.loadFile();
+    // BlockNote가 직렬화 시 base(jsdom: http://localhost:3000/) 기준 절대 URL을 뱉은 상황
+    await b.saveFile('![alt](http://localhost:3000/images/foo.png)\n');
+    const saveCall = (globalThis.fetch as any).mock.calls.find(
+      (c: any[]) => c[0] === 'http://localhost:9000/api/file/save'
+    );
+    expect(JSON.parse(saveCall[1].body).content).toBe('![alt](images/foo.png)\n');
+  });
+
   it('uploadImage POSTs multipart', async () => {
     (globalThis.fetch as any).mockResolvedValue({
       ok: true,

--- a/frontend/src/bridge/__tests__/transform.test.ts
+++ b/frontend/src/bridge/__tests__/transform.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { splitFrontmatter, joinFrontmatter } from '../transform';
+
+describe('splitFrontmatter', () => {
+  it('맨 앞 YAML frontmatter를 본문과 분리', () => {
+    const md = '---\ntitle: Post\ntags: [a, b]\n---\n\n# Body\n\ntext\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(frontmatter).toBe('---\ntitle: Post\ntags: [a, b]\n---\n');
+    expect(body).toBe('\n# Body\n\ntext\n');
+  });
+
+  it('frontmatter가 없으면 frontmatter는 빈 문자열, body는 원본', () => {
+    const md = '# Just heading\n\ntext\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(frontmatter).toBe('');
+    expect(body).toBe(md);
+  });
+
+  it('본문 중간의 --- 구분선은 frontmatter로 보지 않는다', () => {
+    const md = 'intro\n\n---\n\nmore\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(frontmatter).toBe('');
+    expect(body).toBe(md);
+  });
+
+  it('BOM이 앞에 있어도 분리', () => {
+    const md = '﻿---\ntitle: X\n---\nbody\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(frontmatter).toBe('﻿---\ntitle: X\n---\n');
+    expect(body).toBe('body\n');
+  });
+
+  it('CRLF 줄바꿈도 처리', () => {
+    const md = '---\r\ntitle: X\r\n---\r\nbody\r\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(frontmatter).toBe('---\r\ntitle: X\r\n---\r\n');
+    expect(body).toBe('body\r\n');
+  });
+});
+
+describe('joinFrontmatter', () => {
+  it('frontmatter를 body 앞에 그대로 붙인다', () => {
+    expect(joinFrontmatter('---\ntitle: X\n---\n', '\n# Body\n')).toBe('---\ntitle: X\n---\n\n# Body\n');
+  });
+
+  it('frontmatter가 빈 문자열이면 body만 반환', () => {
+    expect(joinFrontmatter('', '# Body\n')).toBe('# Body\n');
+  });
+
+  it('split → join 라운드트립이 원본을 보존', () => {
+    const md = '---\ntitle: Post\n---\n\n# Body\n\ntext\n';
+    const { frontmatter, body } = splitFrontmatter(md);
+    expect(joinFrontmatter(frontmatter, body)).toBe(md);
+  });
+});

--- a/frontend/src/bridge/imageMap.ts
+++ b/frontend/src/bridge/imageMap.ts
@@ -1,0 +1,40 @@
+// 이미지 경로 역변환 (옵션 B: 비편집 영역 보존)
+//
+// BlockNote는 마크다운을 파싱할 때 상대경로 이미지를 문서 base URI 기준 절대 URL로
+// 해석한다(예: `images/foo.png` → `http://localhost:<port>/markora/images/foo.png`).
+// 그대로 저장하면 파일에 localhost 절대 URL이 박혀 깨진다. 그래서 로드 시 (절대 URL →
+// 원본 경로) 매핑을 만들어 두고, 저장 시 직렬화된 절대 URL을 원본 경로로 되돌린다.
+
+// 마크다운 이미지 링크에서 경로(target)를 뽑는 정규식. `![alt](target)` / `![alt](target "title")`.
+const IMAGE_LINK_RE = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+// 링크/이미지의 `](target)` 또는 `](target "title")` 부분.
+const LINK_TARGET_RE = /\]\(([^)\s]+)((?:\s+"[^"]*")?)\)/g;
+
+const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const DATA_URL_RE = /^data:/i;
+
+export function collectImageUrlMap(md: string, baseUri: string): Map<string, string> {
+  const map = new Map<string, string>();
+  IMAGE_LINK_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = IMAGE_LINK_RE.exec(md)) !== null) {
+    const original = m[1];
+    // 이미 절대 URL이거나 data URL이면 BlockNote가 재작성하지 않으므로 매핑 불필요
+    if (ABSOLUTE_URL_RE.test(original) || DATA_URL_RE.test(original)) continue;
+    try {
+      const abs = new URL(original, baseUri).href;
+      map.set(abs, original);
+    } catch {
+      /* 잘못된 경로는 건너뜀 */
+    }
+  }
+  return map;
+}
+
+export function restoreImagePaths(md: string, map: Map<string, string>): string {
+  if (map.size === 0) return md;
+  return md.replace(LINK_TARGET_RE, (whole, url: string, title: string) => {
+    const original = map.get(url);
+    return original ? `](${original}${title})` : whole;
+  });
+}

--- a/frontend/src/bridge/markora.ts
+++ b/frontend/src/bridge/markora.ts
@@ -1,4 +1,6 @@
 import type { BridgeContext, MarkoraBridge, Theme, UploadResult } from '../types';
+import { splitFrontmatter, joinFrontmatter } from './transform';
+import { collectImageUrlMap, restoreImagePaths } from './imageMap';
 
 export function parseQueryContext(href: string): BridgeContext {
   const url = new URL(href);
@@ -10,6 +12,11 @@ export function parseQueryContext(href: string): BridgeContext {
 
 export function createBridge(ctx: BridgeContext): MarkoraBridge {
   const themeListeners = new Set<(t: Theme) => void>();
+  // 로드 시 떼어낸 frontmatter를 보관했다가 저장 시 그대로 다시 붙인다.
+  // (frontmatter는 BlockNote를 거치지 않으므로 손상되지 않는다)
+  let storedFrontmatter = '';
+  // (BlockNote가 재작성한 절대 이미지 URL → 원본 경로) 매핑. 저장 시 역변환에 사용.
+  const imageMap = new Map<string, string>();
 
   // Window-level callback Kotlin이 호출
   if (typeof window !== 'undefined') {
@@ -29,14 +36,23 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       );
       if (!res.ok) throw new Error(`loadFile failed: ${res.status}`);
       const data = await res.json();
-      return data.content ?? '';
+      const { frontmatter, body } = splitFrontmatter(data.content ?? '');
+      storedFrontmatter = frontmatter;
+      // 본문의 상대경로 이미지를 BlockNote가 재작성할 절대 URL로 미리 매핑해 둔다.
+      const baseUri = typeof document !== 'undefined' ? document.baseURI : ctx.serverUrl;
+      for (const [abs, original] of collectImageUrlMap(body, baseUri)) {
+        imageMap.set(abs, original);
+      }
+      return body;
     },
 
     async saveFile(markdown: string) {
+      const restored = restoreImagePaths(markdown, imageMap);
+      const content = joinFrontmatter(storedFrontmatter, restored);
       const res = await fetch(`${ctx.serverUrl}api/file/save`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: ctx.filePath, content: markdown }),
+        body: JSON.stringify({ path: ctx.filePath, content }),
       });
       if (!res.ok) throw new Error(`saveFile failed: ${res.status}`);
     },
@@ -60,6 +76,8 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       const dir = normalized.substring(0, normalized.lastIndexOf('/'));
       const absolutePath = `${dir}/${relativePath}`;
       const url = `${ctx.serverUrl}api/local-image?path=${encodeURIComponent(absolutePath)}`;
+      // 저장 시 이 절대 URL을 파일에는 상대경로로 기록하도록 매핑 등록
+      imageMap.set(url, relativePath);
       return { url };
     },
 

--- a/frontend/src/bridge/transform.ts
+++ b/frontend/src/bridge/transform.ts
@@ -1,0 +1,22 @@
+// 브릿지 경계 문자열 변환 (옵션 B: 비편집 영역 보존)
+//
+// BlockNote의 마크다운 라운드트립은 YAML frontmatter를 파괴한다(예: `---` → `***`).
+// frontmatter는 편집 대상이 아니므로, 로드 시 본문과 분리해 보관하고 저장 시 본문 앞에
+// 그대로 다시 붙인다. 이렇게 하면 frontmatter가 BlockNote를 거치지 않아 손상되지 않는다.
+
+const FRONTMATTER_RE = /^(﻿?---\r?\n[\s\S]*?\r?\n---\r?\n)/;
+
+export interface SplitResult {
+  frontmatter: string; // 구분자/줄바꿈 포함, 없으면 ''
+  body: string;
+}
+
+export function splitFrontmatter(md: string): SplitResult {
+  const m = FRONTMATTER_RE.exec(md);
+  if (!m) return { frontmatter: '', body: md };
+  return { frontmatter: m[1], body: md.slice(m[1].length) };
+}
+
+export function joinFrontmatter(frontmatter: string, body: string): string {
+  return frontmatter ? frontmatter + body : body;
+}

--- a/frontend/src/editor/Editor.tsx
+++ b/frontend/src/editor/Editor.tsx
@@ -5,6 +5,7 @@ import '@blocknote/mantine/style.css';
 import type { MarkoraBridge, Theme } from '../types';
 import { schema } from './schema';
 import { postParse, preSerialize, splitInlineMath } from '../markdown/customParse';
+import { checkSaveSafety } from '../markdown/saveGuard';
 import { reinitOnThemeChange } from '../blocks/MermaidBlock';
 
 interface Props {
@@ -65,6 +66,15 @@ export function Editor({ bridge }: Props) {
         try {
           setStatus('Saving...');
           const md = await editor.blocksToMarkdownLossy(preSerialize(editor.document as any) as any);
+          // 손실 가드: 직렬화 결과가 마지막 정상 내용 대비 frontmatter/대량 내용을
+          // 잃었다면 파일을 덮어쓰지 않고 경고만 표시한다 (데이터 파괴 방지).
+          const guard = checkSaveSafety(lastKnownContentRef.current, md);
+          if (!guard.safe) {
+            console.warn('save blocked by guard:', guard.reason, { md });
+            isDirtyRef.current = true; // 미저장 상태 유지
+            setStatus(`⚠ Save blocked: ${guard.reason}`);
+            return;
+          }
           await bridge.saveFile(md);
           lastKnownContentRef.current = md;
           isDirtyRef.current = false;

--- a/frontend/src/markdown/__tests__/saveGuard.test.ts
+++ b/frontend/src/markdown/__tests__/saveGuard.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { checkSaveSafety, hasFrontmatter } from '../saveGuard';
+
+describe('hasFrontmatter', () => {
+  it('YAML frontmatter로 시작하면 true', () => {
+    expect(hasFrontmatter('---\ntitle: Hi\ntags: [a]\n---\n\n# Body\n')).toBe(true);
+  });
+  it('BOM이 앞에 붙어도 인식', () => {
+    expect(hasFrontmatter('﻿---\ntitle: Hi\n---\nbody')).toBe(true);
+  });
+  it('frontmatter 없으면 false', () => {
+    expect(hasFrontmatter('# Just a heading\n\ntext')).toBe(false);
+  });
+  it('본문 중간의 --- 구분선은 frontmatter가 아니다', () => {
+    expect(hasFrontmatter('text\n\n---\n\nmore')).toBe(false);
+  });
+});
+
+describe('checkSaveSafety', () => {
+  it('frontmatter가 사라지는 저장은 차단', () => {
+    const previous = '---\ntitle: Post\n---\n\n# Body\n\ncontent here\n';
+    // 라운드트립이 frontmatter를 ***/setext로 깨뜨린 결과
+    const next = '***\n\ntitle: Post\n------------\n\n# Body\n\ncontent here\n';
+    const r = checkSaveSafety(previous, next);
+    expect(r.safe).toBe(false);
+    expect(r.reason).toMatch(/frontmatter/i);
+  });
+
+  it('frontmatter가 보존되면 허용', () => {
+    const previous = '---\ntitle: Post\n---\n\n# Body\n';
+    const next = '---\ntitle: Post\n---\n\n# Body edited\n';
+    expect(checkSaveSafety(previous, next).safe).toBe(true);
+  });
+
+  it('frontmatter 없는 문서의 일반 편집은 허용', () => {
+    const previous = '# Heading\n\nsome paragraph text that is reasonably long\n';
+    const next = '# Heading\n\nsome paragraph text that is reasonably long, edited\n';
+    expect(checkSaveSafety(previous, next).safe).toBe(true);
+  });
+
+  it('내용 대부분(50%+, 50자+)이 사라지는 저장은 차단', () => {
+    const previous = 'A'.repeat(100) + '\n' + 'B'.repeat(100) + '\n';
+    const next = 'A'.repeat(20) + '\n';
+    const r = checkSaveSafety(previous, next);
+    expect(r.safe).toBe(false);
+    expect(r.reason).toMatch(/content/i);
+  });
+
+  it('작은 문서에서의 비율 큰 삭제는 오탐하지 않는다 (절대 손실 < 50자)', () => {
+    const previous = 'hello world\n';   // 12자
+    const next = 'hi\n';                  // 3자, 75% 줄지만 절대 9자
+    expect(checkSaveSafety(previous, next).safe).toBe(true);
+  });
+
+  it('빈 previous는 항상 안전', () => {
+    expect(checkSaveSafety('', 'anything new').safe).toBe(true);
+  });
+});

--- a/frontend/src/markdown/saveGuard.ts
+++ b/frontend/src/markdown/saveGuard.ts
@@ -1,0 +1,53 @@
+// 저장 직전 손실 가드 (옵션 C: 즉시 출혈 방지)
+//
+// blocksToMarkdownLossy 라운드트립은 BlockNote가 모델링하지 못하는 구조
+// (YAML frontmatter, HTML 블록 등)를 삭제·파괴한다. Editor는 편집이 일어날 때마다
+// 문서 전체를 이 손실 변환으로 재직렬화해 파일을 통째로 덮어쓰므로, 한 번의 사소한
+// 편집만으로도 frontmatter/내용이 영구히 손실될 수 있다.
+//
+// 이 가드는 저장 직전 직렬화 결과(next)를 마지막으로 알려진 정상 내용(previous)과
+// 비교하여 명백한 손실이 감지되면 저장을 차단한다. 근본 해결(손실 없는 직렬화)이
+// 아니라, 데이터 파괴를 멈추기 위한 안전장치다.
+
+export interface SaveGuardResult {
+  safe: boolean;
+  reason?: string;
+  lostChars: number;
+  lostRatio: number;
+}
+
+// previous 대비 이 비율 이상 사라지고(SHRINK_RATIO) 절대 손실도 MIN_ABSOLUTE_LOSS자
+// 이상일 때만 차단한다. 작은 문서에서의 정상적인 대량 삭제 오탐을 줄이기 위함.
+const SHRINK_RATIO = 0.5;
+const MIN_ABSOLUTE_LOSS = 50;
+
+// 문서 맨 앞(BOM 허용)의 `---\n ... \n---\n` 블록만 frontmatter로 인정.
+// 본문 중간의 --- 구분선은 매칭되지 않는다.
+const FRONTMATTER_RE = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/;
+
+export function hasFrontmatter(md: string): boolean {
+  return FRONTMATTER_RE.test(md);
+}
+
+export function checkSaveSafety(previous: string, next: string): SaveGuardResult {
+  const prevLen = previous.length;
+  const lostChars = prevLen - next.length;
+  const lostRatio = prevLen > 0 ? lostChars / prevLen : 0;
+
+  // 1) frontmatter 파괴 감지: 원본엔 있었는데 저장본엔 사라짐/깨짐
+  if (hasFrontmatter(previous) && !hasFrontmatter(next)) {
+    return { safe: false, reason: 'frontmatter would be lost', lostChars, lostRatio };
+  }
+
+  // 2) 대량 내용 손실 감지 (예: HTML 블록 삭제로 문서 절반 이상 증발)
+  if (lostChars >= MIN_ABSOLUTE_LOSS && lostRatio >= SHRINK_RATIO) {
+    return {
+      safe: false,
+      reason: `large content loss (${lostChars} chars, ${Math.round(lostRatio * 100)}%)`,
+      lostChars,
+      lostRatio,
+    };
+  }
+
+  return { safe: true, lostChars, lostRatio };
+}


### PR DESCRIPTION
## 문제

markora에서 마크다운을 편집하면 **편집 내용이 사라지거나 기존 내용이 잘리는** 버그.

근본 원인: 편집이 일어날 때마다 문서 전체를 BlockNote의 lossy 변환(`blocksToMarkdownLossy`)으로 재직렬화해 파일을 통째로 덮어쓴다. BlockNote가 모델링하지 못하는 구조는 첫 편집 시점에 영구 손실된다.

라운드트립 재현 증거:

| 입력 | 저장 후 | 판정 |
|---|---|---|
| `<div>...</div>` HTML 블록 | 완전 삭제 | 🔴 |
| `---\ntitle:...\n---` frontmatter | `***`/setext로 깨짐 | 🔴 |
| `![alt](images/foo.png)` | `![alt](http://localhost:.../images/foo.png)` | 🔴 |

블로그 글은 거의 모두 frontmatter + 상대경로 이미지를 쓰므로 **한 글자만 편집해도** 깨졌다.

## 해결

3단계로 접근:

### 1. saveGuard — 출혈 방지 (안전장치)
`frontend/src/markdown/saveGuard.ts`. 저장 직전 직렬화 결과를 마지막 정상 내용과 비교해, **frontmatter 소실** 또는 **대량(50%+, 50자+) 내용 손실**이 감지되면 저장을 차단하고 상태바에 `⚠ Save blocked` 표시(원본 파일 보존).

### 2. frontmatter 보존
`frontend/src/bridge/transform.ts`. 로드 시 frontmatter를 본문에서 분리·보관하고 저장 시 그대로 재부착 — BlockNote를 거치지 않아 손상되지 않는다.

### 3. 이미지 경로 역변환
`frontend/src/bridge/imageMap.ts`. 로드 시 (BlockNote가 재작성할 절대 URL → 원본 상대경로) 매핑을 만들고 업로드 이미지도 등록, 저장 시 직렬화된 localhost 절대 URL을 원본 경로로 복원.

## 보류 (별도 후속)

**HTML 블록 보존**: `tryParseMarkdownToBlocks`가 블록 생성 이전에 HTML을 버리는 구조라 코드블록 우회가 필요한데, 에디터에서 HTML이 코드블록으로 보이는 UX 변화 + 인라인 HTML 손실 한계가 있어 보류. catastrophic HTML 손실은 saveGuard가 차단한다.

## Test plan

- [x] 신규 단위 테스트 30개 (saveGuard 10, transform 8, imageMap 10, bridge 통합 2)
- [x] 전체 131개 테스트 통과 (`npm test`)
- [x] vite 번들 빌드 성공 (`npm run build`)
- [ ] 실제 IDE 샌드박스(`./gradlew runIde`)에서 frontmatter/이미지 포함 블로그 글 편집 후 파일 무손상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)