### PR TITLE
fix: replace deprecated ReadAction.compute with Application.runReadAction

### DIFF
--- a/src/main/kotlin/com/github/kenshin579/markora/controller/MarkdownFileController.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/controller/MarkdownFileController.kt
@@ -1,11 +1,11 @@
 package com.github.kenshin579.markora.controller
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs.LocalFileSystem
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
@@ -47,9 +47,11 @@ object MarkdownFileController {
             return true
         }
 
-        val content = ReadAction.compute<String, Throwable> {
-            FileDocumentManager.getInstance().getDocument(virtualFile)?.text ?: ""
-        }
+        val content = ApplicationManager.getApplication().runReadAction(
+            Computable {
+                FileDocumentManager.getInstance().getDocument(virtualFile)?.text ?: ""
+            }
+        )
 
         val escapedContent = content
             .replace("\\", "\\\\")


### PR DESCRIPTION
## Summary
- JetBrains Plugin Verifier가 `ReadAction.compute(ThrowableComputable)`를 최신 IDE 빌드(2026.2 EAP / 261 / 253) 기준 **deprecated API 사용**으로 표시함 (0.2.1 compatibility verification 경고)
- 파일 read 엔드포인트(`MarkdownFileController.handleRead`)를 deprecated 아닌 `Application.runReadAction(Computable)`로 교체
- 동기(Netty HTTP 핸들러) 컨텍스트에 맞는 동일한 read-lock 시맨틱, 동작 변화 없음

## Test plan
- [x] `./gradlew compileKotlin` (JDK 21) BUILD SUCCESSFUL
- [x] `./gradlew runIde` 로컬 구동 → `api/file/read` HTTP 200, 파일 내용 정상 반환
- [x] 변경 관련 오류 로그 없음