### PR TITLE
fix: 외부 편집 시 Markora 파일 짤림/누락 방지 (reload 트리거 + 저장 클로버 가드)

### DIFF
--- a/frontend/src/bridge/__tests__/markora.test.ts
+++ b/frontend/src/bridge/__tests__/markora.test.ts
@@ -85,6 +85,42 @@ describe('createBridge (real fetch)', () => {
     expect(JSON.parse(saveCall[1].body).content).toBe('![alt](images/foo.png)\n');
   });
 
+  it('peekFile은 read 엔드포인트에서 본문(frontmatter 제거)을 반환한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '---\ntitle: Post\n---\n\n# Body\n' }),
+    });
+    const b = createBridge(ctx);
+    const body = await b.peekFile();
+    expect(body).toBe('\n# Body\n');
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://localhost:9000/api/file/read?path=%2Ftmp%2Fx.md'
+    );
+  });
+
+  it('peekFile은 storedFrontmatter/imageMap을 변경하지 않는다 (부작용 없음)', async () => {
+    const b = createBridge(ctx);
+    // 1) 최초 load: frontmatter F1 보관
+    (globalThis.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: '---\ntitle: F1\n---\n\n# Body\n' }),
+    });
+    await b.loadFile();
+    // 2) peekFile: 디스크가 다른 frontmatter F2로 바뀐 상태를 들여다봄
+    (globalThis.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: '---\ntitle: F2\n---\n\n# Body changed externally\n' }),
+    });
+    await b.peekFile();
+    // 3) save: peek이 storedFrontmatter를 오염시켰다면 F2가 붙는다. F1이어야 정상.
+    (globalThis.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    await b.saveFile('\n# Body\n');
+    const saveCall = (globalThis.fetch as any).mock.calls.find(
+      (c: any[]) => c[0] === 'http://localhost:9000/api/file/save'
+    );
+    expect(JSON.parse(saveCall[1].body).content).toBe('---\ntitle: F1\n---\n\n# Body\n');
+  });
+
   it('uploadImage POSTs multipart', async () => {
     (globalThis.fetch as any).mockResolvedValue({
       ok: true,
@@ -128,6 +164,24 @@ describe('uploadImage edge cases', () => {
     // Path should not contain undefined and should use forward slashes
     expect(result.url).not.toContain('undefined');
     expect(result.url).toContain('C%3A%2FUsers%2Ffoo%2Fimages%2Fa.png');
+  });
+});
+
+describe('onReloadRequest', () => {
+  it('window.markora.reloadFromDisk() 호출 시 등록된 콜백이 실행된다', () => {
+    const b = createBridge({
+      filePath: '/tmp/x.md',
+      serverUrl: 'http://localhost:9000/',
+      initialTheme: 'light',
+    });
+    const cb = vi.fn();
+    const unsub = b.onReloadRequest(cb);
+    window.markora.reloadFromDisk();
+    expect(cb).toHaveBeenCalled();
+    cb.mockClear();
+    unsub();
+    window.markora.reloadFromDisk();
+    expect(cb).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/bridge/markora.ts
+++ b/frontend/src/bridge/markora.ts
@@ -12,6 +12,7 @@ export function parseQueryContext(href: string): BridgeContext {
 
 export function createBridge(ctx: BridgeContext): MarkoraBridge {
   const themeListeners = new Set<(t: Theme) => void>();
+  const reloadListeners = new Set<() => void>();
   // 로드 시 떼어낸 frontmatter를 보관했다가 저장 시 그대로 다시 붙인다.
   // (frontmatter는 BlockNote를 거치지 않으므로 손상되지 않는다)
   let storedFrontmatter = '';
@@ -23,6 +24,9 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
     window.markora = {
       applyTheme: (t: Theme) => {
         themeListeners.forEach(cb => cb(t));
+      },
+      reloadFromDisk: () => {
+        reloadListeners.forEach(cb => cb());
       },
     };
   }
@@ -43,6 +47,18 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       for (const [abs, original] of collectImageUrlMap(body, baseUri)) {
         imageMap.set(abs, original);
       }
+      return body;
+    },
+
+    // loadFile과 달리 storedFrontmatter/imageMap을 건드리지 않고 디스크 본문만 반환.
+    // 저장 직전 외부 편집 여부를 확인하는 용도라 부작용이 있으면 안 된다.
+    async peekFile() {
+      const res = await fetch(
+        `${ctx.serverUrl}api/file/read?path=${encodeURIComponent(ctx.filePath)}`
+      );
+      if (!res.ok) throw new Error(`peekFile failed: ${res.status}`);
+      const data = await res.json();
+      const { body } = splitFrontmatter(data.content ?? '');
       return body;
     },
 
@@ -85,6 +101,11 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       themeListeners.add(cb);
       return () => themeListeners.delete(cb);
     },
+
+    onReloadRequest(cb) {
+      reloadListeners.add(cb);
+      return () => reloadListeners.delete(cb);
+    },
   };
 }
 
@@ -92,16 +113,20 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
 export function createMockBridge(): MarkoraBridge {
   let storedMd = '# Markora dev mock\n\n*편집 가능합니다.*\n';
   const themeListeners = new Set<(t: Theme) => void>();
+  const reloadListeners = new Set<() => void>();
   if (typeof window !== 'undefined') {
     window.markora = {
       applyTheme: (t: Theme) => themeListeners.forEach(cb => cb(t)),
+      reloadFromDisk: () => reloadListeners.forEach(cb => cb()),
     };
   }
   return {
     getContext: () => ({ filePath: '/dev/mock.md', serverUrl: 'http://localhost:5173/', initialTheme: 'light' }),
     async loadFile() { return storedMd; },
+    async peekFile() { return storedMd; },
     async saveFile(md: string) { storedMd = md; console.log('[mock] saved', md.length, 'bytes'); },
     async uploadImage(file: File) { return { url: URL.createObjectURL(file) }; },
     onThemeChange(cb) { themeListeners.add(cb); return () => themeListeners.delete(cb); },
+    onReloadRequest(cb) { reloadListeners.add(cb); return () => reloadListeners.delete(cb); },
   };
 }

--- a/frontend/src/editor/Editor.tsx
+++ b/frontend/src/editor/Editor.tsx
@@ -30,6 +30,8 @@ export function Editor({ bridge }: Props) {
   const lastKnownContentRef = useRef<string>('');
   const saveTimerRef = useRef<number | null>(null);
   const loadedRef = useRef(false);   // 초기 load 완료 여부 (load-induced onChange를 user edit과 구분)
+  // 외부 변경 reload가 트리거하는 onChange를 user edit과 구분 (reload된 내용을 즉시 lossy 저장으로 되덮는 것 방지)
+  const applyingRemoteRef = useRef(false);
 
   // 초기 로드
   useEffect(() => {
@@ -59,6 +61,9 @@ export function Editor({ bridge }: Props) {
     return editor.onChange(() => {
       // 초기 load가 트리거한 onChange는 무시 (user edit만 dirty 처리)
       if (!loadedRef.current) return;
+      // 외부 변경 reload(replaceBlocks)가 트리거한 onChange도 user edit이 아니므로 무시.
+      // (이게 없으면 reload 직후 1초 뒤 lossy 직렬화로 방금 불러온 외부 내용을 되덮어쓴다)
+      if (applyingRemoteRef.current) return;
       isDirtyRef.current = true;
       setStatus('Modified');
       if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
@@ -66,9 +71,13 @@ export function Editor({ bridge }: Props) {
         try {
           setStatus('Saving...');
           const md = await editor.blocksToMarkdownLossy(preSerialize(editor.document as any) as any);
-          // 손실 가드: 직렬화 결과가 마지막 정상 내용 대비 frontmatter/대량 내용을
-          // 잃었다면 파일을 덮어쓰지 않고 경고만 표시한다 (데이터 파괴 방지).
-          const guard = checkSaveSafety(lastKnownContentRef.current, md);
+          // 저장 직전 디스크 현재 본문을 부작용 없이 읽어 외부 편집(터미널/다른 프로세스)을 확인한다.
+          // 읽기에 실패하면 disk=undefined로 두어 기존 가드(2-인자)로만 검사한다.
+          let disk: string | undefined;
+          try { disk = await bridge.peekFile(); } catch { disk = undefined; }
+          // 손실 가드: 직렬화 결과가 마지막 정상 내용/디스크 대비 frontmatter·대량 내용을
+          // 잃었다면 파일을 덮어쓰지 않고 경고만 표시한다 (데이터 파괴/외부 편집 클로버 방지).
+          const guard = checkSaveSafety(lastKnownContentRef.current, md, disk);
           if (!guard.safe) {
             console.warn('save blocked by guard:', guard.reason, { md });
             isDirtyRef.current = true; // 미저장 상태 유지
@@ -120,20 +129,30 @@ export function Editor({ bridge }: Props) {
     });
   }, [editor]);
 
-  // 외부 변경 감지 (focus)
+  // 외부 변경 reload 핸들러: JCEF 'focus' 이벤트(불안정)와 Kotlin이 IDE 활성화/VFS 변경 시
+  // 호출하는 bridge.onReloadRequest 양쪽에 바인딩한다.
   useEffect(() => {
-    const handler = async () => {
+    const reload = async () => {
       if (isDirtyRef.current) return;
       try {
         const md = await bridge.loadFile();
         if (md === lastKnownContentRef.current) return;
+        // reload가 트리거하는 onChange를 user edit으로 오인해 되저장하지 않도록 억제.
+        // (loadedRef와 동일한 패턴: replaceBlocks 동안 플래그 on, 다음 tick에 off)
+        applyingRemoteRef.current = true;
         const blocks = await editor.tryParseMarkdownToBlocks(md);
         editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
         lastKnownContentRef.current = md;
-      } catch { /* 무시 */ }
+        isDirtyRef.current = false;
+        window.setTimeout(() => { applyingRemoteRef.current = false; }, 0);
+      } catch { applyingRemoteRef.current = false; /* 무시 */ }
     };
-    window.addEventListener('focus', handler);
-    return () => window.removeEventListener('focus', handler);
+    window.addEventListener('focus', reload);
+    const unsub = bridge.onReloadRequest(reload);
+    return () => {
+      window.removeEventListener('focus', reload);
+      unsub();
+    };
   }, [bridge, editor]);
 
   // 테마 동기화

--- a/frontend/src/markdown/__tests__/saveGuard.test.ts
+++ b/frontend/src/markdown/__tests__/saveGuard.test.ts
@@ -56,3 +56,47 @@ describe('checkSaveSafety', () => {
     expect(checkSaveSafety('', 'anything new').safe).toBe(true);
   });
 });
+
+describe('checkSaveSafety: 외부 편집 클로버 가드 (disk 인자)', () => {
+  const lines = (n: number, prefix = 'line') =>
+    Array.from({ length: n }, (_, i) => `${prefix} ${i}`).join('\n') + '\n';
+
+  it('디스크가 마지막 동기화본보다 커졌고(외부 추가) 저장본이 대폭 짧으면 차단', () => {
+    const previous = lines(20);          // markora가 마지막으로 본 내용
+    const disk = lines(40);              // 터미널(외부)에서 줄이 추가됨
+    const next = lines(5);               // lossy 직렬화 결과(짤림)
+    const r = checkSaveSafety(previous, next, disk);
+    expect(r.safe).toBe(false);
+    expect(r.reason).toMatch(/external/i);
+  });
+
+  it('캡처 사례 재현: 디스크 621줄인데 저장본 346줄이면 차단', () => {
+    const previous = lines(500);         // markora가 본 옛 내용(이미 stale)
+    const disk = lines(621);             // Claude Code가 만든 실제 디스크 내용
+    const next = lines(346);             // BlockNote lossy 직렬화(코드블록 중간 짤림)
+    const r = checkSaveSafety(previous, next, disk);
+    expect(r.safe).toBe(false);
+    expect(r.reason).toMatch(/external/i);
+  });
+
+  it('외부 편집이 없으면(disk == previous) 일반 편집은 허용 — 회귀 방지', () => {
+    const previous = lines(30);
+    const next = lines(30).replace('line 0', 'line 0 edited');
+    expect(checkSaveSafety(previous, next, previous).safe).toBe(true);
+  });
+
+  it('disk 미제공이면 기존 2-인자 동작 유지 — 회귀 방지', () => {
+    const previous = '# Heading\n\nsome paragraph text that is reasonably long\n';
+    const next = '# Heading\n\nsome paragraph text that is reasonably long, edited\n';
+    expect(checkSaveSafety(previous, next).safe).toBe(true);
+  });
+
+  it('이미지 URL 표현 차이로 disk!=previous지만 줄 수/내용이 사실상 같으면 차단하지 않음 (오탐 방지)', () => {
+    // 저장 후 previous(lastKnown)에는 절대 URL, disk에는 상대경로가 들어가 문자열은 다르지만
+    // 줄 수와 실내용은 동일 → 외부 편집이 아니므로 허용해야 한다.
+    const previous = '# Doc\n\n![a](http://localhost:63342/api/local-image?path=%2Fp%2Fimages%2Fa.png)\n\nbody\n';
+    const disk = '# Doc\n\n![a](images/a.png)\n\nbody\n';
+    const next = '# Doc\n\n![a](http://localhost:63342/api/local-image?path=%2Fp%2Fimages%2Fa.png)\n\nbody edited\n';
+    expect(checkSaveSafety(previous, next, disk).safe).toBe(true);
+  });
+});

--- a/frontend/src/markdown/saveGuard.ts
+++ b/frontend/src/markdown/saveGuard.ts
@@ -21,6 +21,16 @@ export interface SaveGuardResult {
 const SHRINK_RATIO = 0.5;
 const MIN_ABSOLUTE_LOSS = 50;
 
+// 외부 편집 클로버 가드: 저장 직전 디스크 내용이 markora의 마지막 동기화본과
+// 달라졌다면(터미널/다른 프로세스가 편집), lossy 직렬화 결과가 디스크 내용을
+// 잘라먹는 것을 막기 위해 더 민감한 줄 수 기준을 적용한다.
+const EXTERNAL_LINE_SHRINK_RATIO = 0.3;
+const MIN_ABSOLUTE_LINE_LOSS = 10;
+
+function lineCount(s: string): number {
+  return s.length === 0 ? 0 : s.split('\n').length;
+}
+
 // 문서 맨 앞(BOM 허용)의 `---\n ... \n---\n` 블록만 frontmatter로 인정.
 // 본문 중간의 --- 구분선은 매칭되지 않는다.
 const FRONTMATTER_RE = /^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/;
@@ -29,7 +39,10 @@ export function hasFrontmatter(md: string): boolean {
   return FRONTMATTER_RE.test(md);
 }
 
-export function checkSaveSafety(previous: string, next: string): SaveGuardResult {
+// previous: markora가 마지막으로 정상이라 판단한 내용(lastKnownContent)
+// next:     이번에 저장하려는 직렬화 결과
+// disk:     (선택) 저장 직전 디스크에서 다시 읽은 현재 본문. 외부 편집 클로버 검출용.
+export function checkSaveSafety(previous: string, next: string, disk?: string): SaveGuardResult {
   const prevLen = previous.length;
   const lostChars = prevLen - next.length;
   const lostRatio = prevLen > 0 ? lostChars / prevLen : 0;
@@ -39,7 +52,30 @@ export function checkSaveSafety(previous: string, next: string): SaveGuardResult
     return { safe: false, reason: 'frontmatter would be lost', lostChars, lostRatio };
   }
 
-  // 2) 대량 내용 손실 감지 (예: HTML 블록 삭제로 문서 절반 이상 증발)
+  // 2) 외부 편집 클로버 감지: 디스크가 마지막 동기화본과 달라졌다면(외부 편집),
+  //    저장본(next)이 디스크 대비 대량의 줄/문자를 잃을 때 차단한다. 이 가드가
+  //    previous 기준 검사(레이어 3)보다 먼저 동작해야 stale한 previous 때문에
+  //    50% 미만으로 보이는 외부 클로버(예: 디스크 621줄 → 346줄)를 잡을 수 있다.
+  if (disk !== undefined && disk !== previous) {
+    const diskLines = lineCount(disk);
+    const nextLines = lineCount(next);
+    const lostLines = diskLines - nextLines;
+    const lostLineRatio = diskLines > 0 ? lostLines / diskLines : 0;
+    const diskLostChars = disk.length - next.length;
+    const diskLostRatio = disk.length > 0 ? diskLostChars / disk.length : 0;
+    const lineLoss = lostLines >= MIN_ABSOLUTE_LINE_LOSS && lostLineRatio >= EXTERNAL_LINE_SHRINK_RATIO;
+    const charLoss = diskLostChars >= MIN_ABSOLUTE_LOSS && diskLostRatio >= SHRINK_RATIO;
+    if (lineLoss || charLoss) {
+      return {
+        safe: false,
+        reason: `external edit would be overwritten (disk ${diskLines} lines → ${nextLines} lines)`,
+        lostChars: diskLostChars,
+        lostRatio: diskLostRatio,
+      };
+    }
+  }
+
+  // 3) 대량 내용 손실 감지 (예: HTML 블록 삭제로 문서 절반 이상 증발)
   if (lostChars >= MIN_ABSOLUTE_LOSS && lostRatio >= SHRINK_RATIO) {
     return {
       safe: false,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,15 +13,21 @@ export interface UploadResult {
 export interface MarkoraBridge {
   getContext(): BridgeContext;
   loadFile(): Promise<string>;
+  // 디스크 현재 본문을 부작용 없이 읽어온다 (저장 직전 외부 편집 충돌 검출용).
+  peekFile(): Promise<string>;
   saveFile(markdown: string): Promise<void>;
   uploadImage(file: File): Promise<UploadResult>;
   onThemeChange(cb: (t: Theme) => void): () => void;
+  // Kotlin이 외부 파일 변경(IDE 활성화/VFS 변경)을 감지해 reload를 요청할 때 호출되는 콜백 등록.
+  onReloadRequest(cb: () => void): () => void;
 }
 
 declare global {
   interface Window {
     markora: {
       applyTheme: (t: Theme) => void;
+      // Kotlin이 IDE 활성화/외부 변경 감지 시 호출하여 외부 디스크 변경 reload를 요청.
+      reloadFromDisk: () => void;
     };
   }
 }

--- a/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownHtmlPanel.kt
+++ b/src/main/kotlin/com/github/kenshin579/markora/editor/MarkdownHtmlPanel.kt
@@ -3,10 +3,13 @@ package com.github.kenshin579.markora.editor
 import com.github.kenshin579.markora.controller.PreviewStaticServer
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationActivationListener
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.IdeFrame
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
@@ -31,6 +34,26 @@ class MarkdownHtmlPanel(
     init {
         setupHandlers()
         loadEditor()
+        subscribeExternalChangeReload()
+    }
+
+    // IDE가 다시 활성화될 때(터미널/다른 앱에서 돌아옴) 디스크 상태가 외부에서 변경됐을 수
+    // 있다. JCEF 임베드 브라우저는 JS 'focus' 이벤트를 안정적으로 받지 못하므로 IDE 측에서
+    // 명시적으로 트리거한다.
+    //   1) virtualFile.refresh(async)로 VFS↔Document 동기화
+    //   2) 동기화 완료 후 JS의 window.markora.reloadFromDisk 호출
+    private fun subscribeExternalChangeReload() {
+        val connection = ApplicationManager.getApplication().messageBus.connect(this)
+        connection.subscribe(ApplicationActivationListener.TOPIC, object : ApplicationActivationListener {
+            override fun applicationActivated(ideFrame: IdeFrame) {
+                file.refresh(/* async = */ true, /* recursive = */ false) {
+                    // postRunnable은 VFS refresh 완료 후 실행됨. Document가 최신화된 시점에 JS reload 요청.
+                    executeJavaScript(
+                        "try { if (window.markora && typeof window.markora.reloadFromDisk === 'function') { window.markora.reloadFromDisk(); } } catch (e) { console.warn('reloadFromDisk failed', e); }"
+                    )
+                }
+            }
+        })
     }
 
     private fun setupHandlers() {


### PR DESCRIPTION
## 문제

`.md` 파일을 Markora로 연 상태에서 터미널(Claude Code 등)로 외부 편집을 하면 내용이 짤리거나 누락되는 문제. 0.2.1의 lossy-roundtrip `saveGuard` fix와는 **별개 축**인 **two-writer 충돌**이 근본 원인이다.

- 외부 프로세스는 **디스크에 직접** 쓰고, Markora는 **IDE in-memory Document**(`FileDocumentManager.getDocument().text`)에 써서 IDE가 flush → 둘이 동기화되지 않아 lost-update + stale read 발생.
- 캡처 사례: 디스크 621줄이 346줄로 코드블록 중간에서 짤림(기존 saveGuard의 50% 임계 미달이라 통과).

## 변경

**② 저장 클로버 가드**
- 저장 직전 `bridge.peekFile()`(부작용 없는 디스크 재읽기)로 외부 변경 확인.
- `checkSaveSafety(prev, next, disk)`에 `disk` 인자 추가 — 디스크가 마지막 동기화본과 달라졌을 때 줄 수/문자 기준으로 외부 클로버를 차단(50% 미만 짤림도 포착).

**③ 외부 변경 reload**
- JCEF 임베드 브라우저는 JS `window` `'focus'` 이벤트를 안정적으로 받지 못함 → Kotlin `MarkdownHtmlPanel`에서 `ApplicationActivationListener`로 IDE 활성화 감지 → `virtualFile.refresh(async)` 동기화 후 `window.markora.reloadFromDisk()` 호출.
- reload가 트리거하는 `onChange`를 `applyingRemoteRef`로 억제해 방금 불러온 외부 내용을 lossy 직렬화로 되덮어쓰지 않게 함.

bridge에 `peekFile` / `onReloadRequest` / `window.markora.reloadFromDisk` 추가(real + mock).

## 남은 한계 (후속)

- 줄 수가 바뀌지 않는 같은-줄 외부 편집은 ②가 못 잡음.
- `peekFile`도 여전히 IDE Document 경유라 좁은 race에서 stale 가능.
- 정밀 해결은 Kotlin 측 mtime/hash 기반 conflict 검출(①)이 필요.

## Test plan

- [x] 프론트엔드 단위테스트 139개 통과 (신규 8개: saveGuard disk 가드, bridge peekFile/onReloadRequest)
- [x] `runIde` 수동 검증 — ③ 외부 편집 후 IDE 복귀 시 reload 동작
- [x] `runIde` 수동 검증 — ② 동시 편집 시 짤림/누락 없음