### PR TITLE
fix(frontend): scale mermaid diagrams to fill editor width

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -43,8 +43,15 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
 [data-mantine-color-scheme="dark"] .markora-error-box { background: #3a2f0e; color: #f0d780; border-color: #8a6d00; }
 [data-mantine-color-scheme="dark"] .markora-error-actions button { background: #2b2d30; color: #f0d780; border-color: #8a6d00; }
 
-.markora-mermaid-render { padding: 12px; cursor: pointer; text-align: center; }
-.markora-mermaid-render svg { max-width: 100%; }
+/* The render block is a flex item of .bn-block-content (a row flex), so by
+ * default (flex:0 1 auto) it shrinks to the diagram's content width and the
+ * SVG never gets the chance to fill the editor. flex:1 makes it grow to the
+ * full block width; the svg rule then overrides mermaid's inline
+ * `max-width:<naturalWidth>px` cap and caps the diagram at 60% of the editor
+ * width (centered) so it scales up without dominating the page. */
+.markora-mermaid-render { flex: 1; padding: 12px; cursor: pointer; text-align: center; }
+.markora-mermaid-render svg { max-width: 60% !important; width: 100%; height: auto; }
+.markora-mermaid-edit { flex: 1; }
 .markora-mermaid-edit textarea { width: 100%; font-family: ui-monospace, monospace; padding: 8px; box-sizing: border-box; }
 
 /* ----- Code block syntax highlighting (shiki dual theme) -----


### PR DESCRIPTION
## Summary
WYSIWYG 에디터에서 mermaid 다이어그램이 본문 폭에 비해 너무 작게 렌더링되던 문제를 수정합니다.

## Root cause
mermaid 렌더 블록(`.markora-mermaid-render`)은 `.bn-block-content`(BlockNote의 **row flex**)의 flex item이라, 기본값 `flex:0 1 auto`로 **다이어그램 자연 콘텐츠 폭으로 줄어들었습니다.** 이 상태에서는 내부 SVG에 `width:100%`를 줘도 줄어든 부모 기준이라 작게 나옵니다. 추가로 mermaid는 `useMaxWidth:true`라 SVG에 인라인 `style="max-width:<자연폭>px"`를 박아 상한까지 걸려 있었습니다.

## Fix
`frontend/src/styles.css`:
- `.markora-mermaid-render { flex: 1; }` — 렌더 블록이 블록 폭만큼 늘어나도록
- `.markora-mermaid-render svg { max-width: 60% !important; width: 100%; height: auto; }` — mermaid 인라인 cap을 덮어쓰고, 에디터 폭의 60%로 중앙 정렬 스케일

60% 값은 자연폭(약 540px)보다 충분히 크면서 페이지를 압도하지 않는 균형으로 선택했습니다.

## Test plan
- [x] 실제 번들을 띄워 React fiber로 editor 핸들을 얻어 mermaid 블록 주입 후 폭 측정: 렌더 컨테이너 324px → 1332px, SVG는 60% cap에서 785px 확인
- [x] 샌드박스 IDE(`./gradlew runIde`)에서 Phase/짧은/시퀀스 다이어그램이 적정 크기로 렌더되는지 육안 확인