### PR TITLE
fix(frontend): render mermaid labels as SVG text to avoid Korean clipping in JCEF

### DIFF
--- a/frontend/src/blocks/MermaidBlock.tsx
+++ b/frontend/src/blocks/MermaidBlock.tsx
@@ -9,6 +9,12 @@ export function initMermaid(theme: 'light' | 'dark') {
     startOnLoad: false,
     theme: theme === 'dark' ? 'dark' : 'default',
     securityLevel: 'strict',
+    // top-level htmlLabels:false: JCEF의 임베디드 Chromium은 mermaid 기본값인
+    // foreignObject HTML 라벨의 자동 줄바꿈을 적용하지 못해 긴 한글이 고정 폭
+    // 박스를 넘어 짤린다. SVG <text>/<tspan>으로 전환하면 mermaid가
+    // getComputedTextLength 기반으로 직접 wrap하므로 JCEF에서도 안정적이다.
+    // 주의: mermaid 11은 flowchart.htmlLabels 를 무시하므로 반드시 top-level.
+    htmlLabels: false,
   });
   initialized = true;
 }

--- a/frontend/src/blocks/__tests__/mermaid.test.ts
+++ b/frontend/src/blocks/__tests__/mermaid.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mermaid from 'mermaid';
 
 vi.mock('mermaid', () => ({
   default: {
@@ -25,5 +26,18 @@ describe('renderMermaidToSvg', () => {
     const { svg, error } = await renderMermaidToSvg('m2', 'INVALID');
     expect(error).toContain('Parse error');
     expect(svg).toBe('');
+  });
+});
+
+describe('initMermaid config', () => {
+  // JCEF의 임베디드 Chromium은 mermaid 기본값(foreignObject HTML 라벨)의
+  // 자동 줄바꿈을 적용하지 못해 긴 한글이 박스 폭을 넘어 짤린다. mermaid 11에서는
+  // top-level `htmlLabels:false`만 적용돼야 라벨이 SVG <text>/<tspan>으로
+  // 렌더되어 JCEF에서도 안정적으로 wrapping된다(`flowchart.htmlLabels`는 무시됨).
+  it('htmlLabels:false 가 top-level 로 mermaid.initialize 에 전달된다', () => {
+    (mermaid.initialize as any).mockClear();
+    initMermaid('light');
+    const cfg = (mermaid.initialize as any).mock.calls.at(-1)[0];
+    expect(cfg.htmlLabels).toBe(false);
   });
 });


### PR DESCRIPTION
## 문제

mermaid 다이어그램의 긴 한글 노드 라벨이 JCEF에서 박스 폭을 넘어 짤린다 (Typora·표준 Chrome에선 정상 wrapping).

| Typora | Markora (before) |
|---|---|
| `접근 노드 0.3m 이내 첫 지점` / `에서 멈춤, idle` (2줄) | `접근 노드 0.3m 이내 첫 지점에` (1줄, 우측 clip) |

## 원인 분석

`MermaidBlock.tsx`의 `initMermaid`가 `htmlLabels`를 미지정 → mermaid 11 기본값 `htmlLabels:true`로 노드 라벨이 다음과 같이 렌더됨:

```html
<foreignObject width="200" height="48">
  <div style="display:table; white-space:break-spaces; width:200px; max-width:200px">
    <span class="nodeLabel"><p>접근 노드 0.3m 이내 첫 지점에서 멈춤, idle</p></span>
  </div>
</foreignObject>
```

- foreignObject의 width/height(200×48)는 mermaid 렌더 시점에 SVG에 baked-in
- 줄바꿈은 디스플레이 시점에 CSS(`width:200px; white-space:break-spaces`)로 발생해야 함
- **JCEF 임베디드 Chromium은 foreignObject 내부 HTML 라벨의 자동 줄바꿈을 적용하지 못함** → 한 줄로 펼쳐져 200px 폭을 넘어 짤림

표준 Chromium에서 동일 config·CSS로 직접 재현한 결과:
- foreignObject 11개, 모두 200px에서 정상 wrap, clipping 없음
- 스케일 적용 버전도 텍스트와 박스가 비례 확대됨 → CSS 스케일 문제 아님
- 즉 mermaid 출력은 정상이며 짤림은 JCEF의 foreignObject 렌더링 한계

## 수정

`mermaid.initialize`에 **top-level** `htmlLabels: false` 추가:

```ts
mermaid.initialize({
  startOnLoad: false,
  theme: ...,
  securityLevel: 'strict',
  htmlLabels: false, // ← top-level. flowchart.htmlLabels 는 mermaid 11에서 무시됨
});
```

→ 라벨이 `<foreignObject>` 대신 SVG 네이티브 `<text>`/`<tspan>`으로 렌더되어 mermaid 자체가 `getComputedTextLength` 기반으로 wrap. HTML 레이아웃 의존성이 사라져 JCEF에서도 정상 wrapping.

검증된 동등 출력(repro):
- `htmlLabels:true` (기존): foreignObject 11, text 0
- `htmlLabels:false` (top-level): foreignObject 0, text 2, tspan 23 ✓
- `flowchart.htmlLabels:false`만: foreignObject 그대로 → 효과 없음 (주석에 명시)

## Test plan

- [x] vitest 신규: `htmlLabels:false`가 top-level로 `mermaid.initialize`에 전달되는지 설정 잠금
- [x] vitest 전체 회귀: 15 files / 172 tests pass
- [x] `./gradlew runIde` 실측: 문제 .md 열어 한글 노드가 박스 안에 정상 wrap됨 확인

## 미처리 별개 이슈

`styles.css:53`의 `svg { max-width:60% !important; width:100% }`로 좁은 다이어그램이 과도 확대되어 폰트 크기가 다이어그램마다 들쭉날쭉한 현상은 그대로다. clipping과 무관한 별개 문제라 이 PR에서는 손대지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)