### PR TITLE
fix(frontend): mermaid 다이어그램 과대 렌더 수정

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -44,13 +44,19 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
 [data-mantine-color-scheme="dark"] .markora-error-actions button { background: #2b2d30; color: #f0d780; border-color: #8a6d00; }
 
 /* The render block is a flex item of .bn-block-content (a row flex), so by
- * default (flex:0 1 auto) it shrinks to the diagram's content width and the
- * SVG never gets the chance to fill the editor. flex:1 makes it grow to the
- * full block width; the svg rule then overrides mermaid's inline
- * `max-width:<naturalWidth>px` cap and caps the diagram at 60% of the editor
- * width (centered) so it scales up without dominating the page. */
+ * default (flex:0 1 auto) it shrinks to the diagram's content width. flex:1
+ * makes it grow to the full block width so the diagram can be centered.
+ *
+ * DO NOT set width or max-width on the svg. mermaid (useMaxWidth:true) already
+ * emits width="100%" + inline `style="max-width:<naturalWidth>px"`, which makes
+ * small diagrams stop at their natural size and only shrinks diagrams wider than
+ * the editor. Any width:100% / max-width:<n>% rule here OVERRIDES that natural cap
+ * (a % max-width beats mermaid's inline px cap) and upscales small/vertical
+ * (graph TD) diagrams to fill the editor — verified: a 420px-wide diagram blew up
+ * to 586px (max-width:60%) / 976px (max-width:100% + width:auto). Leaving the svg
+ * alone renders it at 420px (natural) and shrinks a 1497px-wide one to fit. */
 .markora-mermaid-render { flex: 1; padding: 12px; cursor: pointer; text-align: center; }
-.markora-mermaid-render svg { max-width: 60% !important; width: 100%; height: auto; }
+.markora-mermaid-render svg { height: auto; }
 .markora-mermaid-edit { flex: 1; }
 .markora-mermaid-edit textarea { width: 100%; font-family: ui-monospace, monospace; padding: 8px; box-sizing: border-box; }
 


### PR DESCRIPTION
## Summary
- 세로형(`graph TD`)·작은 mermaid 다이어그램이 에디터 폭을 가득 채울 만큼 거대하게 렌더되던 문제 수정
- `.markora-mermaid-render svg`의 `max-width:60%!important; width:100%` 규칙을 제거하고 `height:auto`만 남김

## 원인
mermaid(`useMaxWidth:true`, 기본값)는 렌더된 `<svg>`에 `width="100%"` + 인라인 `style="max-width:<자연폭>px"`를 박아 **작은 다이어그램은 자연 크기에서 멈추고 넓은 것만 폭에 맞춰 축소**한다. 그런데 markora CSS의 `max-width:60%!important; width:100%`가 그 자연폭 cap을 무력화(퍼센트 `max-width`가 mermaid의 인라인 px cap을 이김)해 작은 다이어그램을 에디터 폭으로 강제 확대시켰다.

가로형은 자연폭이 커서 티가 안 났고, 세로형에서만 과확대가 드러나 "같은 파일인데 다이어그램마다 다르게 렌더"되는 것처럼 보였다.

## 검증 (Chromium=JCEF 동일 엔진, headless 실측 / 부모폭 1000px, 자연폭 420px 다이어그램)
| CSS | 렌더 폭 |
|---|---|
| `max-width:60%!important; width:100%` (기존) | 586px (확대) |
| `max-width:100%!important; width:auto` | 976px (더 큼) |
| width/max-width 미설정 (`height:auto`만) | **420px (자연폭, 정상)** |

- 자연폭 1497px(부모보다 넓음) 다이어그램은 최종안에서 부모폭 976px로 정상 축소됨을 확인.

## Test plan
- [x] `./gradlew buildFrontend` 성공, 번들 CSS에 `markora-mermaid-render svg{height:auto}` 반영 확인
- [x] `./gradlew runIde` 샌드박스에서 세로형 다이어그램이 자연 크기로 렌더됨을 육안 확인