### PR TITLE
fix: 파일의 상대경로 이미지가 렌더링되지 않는 문제 수정

### DIFF
--- a/frontend/src/bridge/__tests__/imageMap.test.ts
+++ b/frontend/src/bridge/__tests__/imageMap.test.ts
@@ -1,36 +1,60 @@
 import { describe, it, expect } from 'vitest';
-import { collectImageUrlMap, restoreImagePaths } from '../imageMap';
+import { rewriteImagePathsForDisplay, restoreImagePaths } from '../imageMap';
 
-const BASE = 'http://localhost:63342/markora/';
+const SERVER = 'http://localhost:63342/markora/';
+const DIR = '/Users/me/doc';
 
-describe('collectImageUrlMap', () => {
-  it('상대경로 이미지를 base 기준 절대 URL로 매핑 (절대→원본)', () => {
-    const md = '![alt](images/foo.png)\n\ntext\n';
-    const map = collectImageUrlMap(md, BASE);
-    expect(map.get('http://localhost:63342/markora/images/foo.png')).toBe('images/foo.png');
+describe('rewriteImagePathsForDisplay', () => {
+  it('상대경로 이미지를 local-image API URL로 재작성하고 (URL→원본) 매핑을 만든다', () => {
+    const { body, map } = rewriteImagePathsForDisplay(
+      '![alt](images/foo.png)\n\ntext\n',
+      DIR,
+      SERVER,
+    );
+    const url =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/doc/images/foo.png');
+    expect(body).toBe(`![alt](${url})\n\ntext\n`);
+    expect(map.get(url)).toBe('images/foo.png');
   });
 
-  it('./ 와 ../ 상대경로도 매핑', () => {
-    const md = '![a](./a.png) ![b](../b.png)';
-    const map = collectImageUrlMap(md, BASE);
-    expect(map.get('http://localhost:63342/markora/a.png')).toBe('./a.png');
-    expect(map.get('http://localhost:63342/b.png')).toBe('../b.png');
+  it('./ 와 ../ 상대경로를 디스크 절대경로로 해석', () => {
+    const { map } = rewriteImagePathsForDisplay('![a](./_assets/a.png) ![b](../b.png)', DIR, SERVER);
+    const urlA =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/doc/_assets/a.png');
+    const urlB =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/b.png');
+    expect(map.get(urlA)).toBe('./_assets/a.png');
+    expect(map.get(urlB)).toBe('../b.png');
   });
 
-  it('이미 절대 URL(http/https)인 이미지는 매핑하지 않는다', () => {
-    const md = '![x](https://example.com/x.png)';
-    const map = collectImageUrlMap(md, BASE);
+  it('이미 절대 URL(http/https)이나 data URL은 재작성하지 않는다', () => {
+    const md = '![x](https://example.com/x.png) ![y](data:image/png;base64,AAAA)';
+    const { body, map } = rewriteImagePathsForDisplay(md, DIR, SERVER);
+    expect(body).toBe(md);
     expect(map.size).toBe(0);
   });
 
-  it('타이틀이 있어도 경로만 추출', () => {
-    const md = '![a](images/foo.png "caption")';
-    const map = collectImageUrlMap(md, BASE);
-    expect(map.get('http://localhost:63342/markora/images/foo.png')).toBe('images/foo.png');
+  it('타이틀은 보존하면서 경로만 재작성', () => {
+    const { body } = rewriteImagePathsForDisplay('![a](images/foo.png "caption")', DIR, SERVER);
+    const url =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/doc/images/foo.png');
+    expect(body).toBe(`![a](${url} "caption")`);
   });
 
-  it('이미지가 없으면 빈 맵', () => {
-    expect(collectImageUrlMap('# no images', BASE).size).toBe(0);
+  it('이미지가 없으면 원본 그대로, 빈 맵', () => {
+    const { body, map } = rewriteImagePathsForDisplay('# no images', DIR, SERVER);
+    expect(body).toBe('# no images');
+    expect(map.size).toBe(0);
+  });
+
+  it('재작성 후 저장 시 원본 상대경로로 복원된다 (라운드트립)', () => {
+    const original = '![alt](./_assets/a.png "cap")\n';
+    const { body, map } = rewriteImagePathsForDisplay(original, DIR, SERVER);
+    expect(restoreImagePaths(body, map)).toBe(original);
   });
 });
 

--- a/frontend/src/bridge/__tests__/markora.test.ts
+++ b/frontend/src/bridge/__tests__/markora.test.ts
@@ -72,14 +72,28 @@ describe('createBridge (real fetch)', () => {
     expect(JSON.parse(saveCall[1].body).content).toBe('---\ntitle: Post\n---\n\n# Body edited\n');
   });
 
-  it('로드한 상대경로 이미지는 저장 시 절대 URL이 아닌 원본 상대경로로 기록된다', async () => {
+  it('로드 시 상대경로 이미지를 local-image URL로 재작성한다', async () => {
     (globalThis.fetch as any).mockResolvedValue({
       ok: true,
       json: async () => ({ content: '![alt](images/foo.png)\n' }),
     });
     const b = createBridge(ctx);
-    await b.loadFile();
-    await b.saveFile('![alt](http://localhost:3000/images/foo.png)\n', '');
+    const { body } = await b.loadFile();
+    const url =
+      'http://localhost:9000/api/local-image?path=' +
+      encodeURIComponent('/tmp/images/foo.png');
+    expect(body).toBe(`![alt](${url})\n`);
+  });
+
+  it('로드한 상대경로 이미지는 저장 시 local-image URL이 아닌 원본 상대경로로 기록된다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: '![alt](images/foo.png)\n' }),
+    });
+    const b = createBridge(ctx);
+    // 로드가 반환한 본문(= BlockNote가 그대로 직렬화할 내용)을 그대로 저장한다.
+    const { body } = await b.loadFile();
+    await b.saveFile(body, '');
     const saveCall = (globalThis.fetch as any).mock.calls.find(
       (c: any[]) => c[0] === 'http://localhost:9000/api/file/save'
     );

--- a/frontend/src/bridge/imageMap.ts
+++ b/frontend/src/bridge/imageMap.ts
@@ -1,34 +1,49 @@
-// 이미지 경로 역변환 (옵션 B: 비편집 영역 보존)
+// 이미지 경로 변환 (옵션 B: 비편집 영역 보존)
 //
-// BlockNote는 마크다운을 파싱할 때 상대경로 이미지를 문서 base URI 기준 절대 URL로
-// 해석한다(예: `images/foo.png` → `http://localhost:<port>/markora/images/foo.png`).
-// 그대로 저장하면 파일에 localhost 절대 URL이 박혀 깨진다. 그래서 로드 시 (절대 URL →
-// 원본 경로) 매핑을 만들어 두고, 저장 시 직렬화된 절대 URL을 원본 경로로 되돌린다.
+// 파일에 적힌 상대경로 이미지(예: `./_assets/foo.png`)를 그대로 BlockNote에 넘기면,
+// <img>가 JCEF 페이지의 base URI(번들 dist 디렉터리) 기준으로 해석되어 디스크의 실제
+// 파일이 아니라 엉뚱한 곳을 가리킨다 → 렌더링 실패. 그래서 로드 시 상대경로를 IDE가
+// 디스크에서 직접 서빙하는 `api/local-image?path=<절대경로>` URL로 재작성한다.
+// 동시에 (local-image URL → 원본 상대경로) 매핑을 만들어 두고, 저장 시 직렬화된 URL을
+// 원본 상대경로로 되돌려 파일에는 localhost 절대 URL이 박히지 않게 한다.
 
-// 마크다운 이미지 링크에서 경로(target)를 뽑는 정규식. `![alt](target)` / `![alt](target "title")`.
-const IMAGE_LINK_RE = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+// `![alt](target)` / `![alt](target "title")`를 head/target/tail 세 그룹으로 나눈다.
+const IMAGE_REWRITE_RE = /(!\[[^\]]*\]\()([^)\s]+)((?:\s+"[^"]*")?\))/g;
 // 링크/이미지의 `](target)` 또는 `](target "title")` 부분.
 const LINK_TARGET_RE = /\]\(([^)\s]+)((?:\s+"[^"]*")?)\)/g;
 
 const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const DATA_URL_RE = /^data:/i;
 
-export function collectImageUrlMap(md: string, baseUri: string): Map<string, string> {
-  const map = new Map<string, string>();
-  IMAGE_LINK_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = IMAGE_LINK_RE.exec(md)) !== null) {
-    const original = m[1];
-    // 이미 절대 URL이거나 data URL이면 BlockNote가 재작성하지 않으므로 매핑 불필요
-    if (ABSOLUTE_URL_RE.test(original) || DATA_URL_RE.test(original)) continue;
-    try {
-      const abs = new URL(original, baseUri).href;
-      map.set(abs, original);
-    } catch {
-      /* 잘못된 경로는 건너뜀 */
+// `dir` 기준으로 상대경로 `rel`을 디스크 절대경로로 해석한다. `.`/`..` 세그먼트 처리.
+function resolveAgainstDir(dir: string, rel: string): string {
+  const parts = dir.replace(/\\/g, '/').replace(/\/+$/, '').split('/');
+  for (const seg of rel.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      if (parts.length > 1) parts.pop();
+    } else {
+      parts.push(seg);
     }
   }
-  return map;
+  return parts.join('/');
+}
+
+export function rewriteImagePathsForDisplay(
+  md: string,
+  mdDir: string,
+  serverUrl: string,
+): { body: string; map: Map<string, string> } {
+  const map = new Map<string, string>();
+  const body = md.replace(IMAGE_REWRITE_RE, (whole, head: string, target: string, tail: string) => {
+    // 이미 절대 URL이거나 data URL이면 디스크 파일이 아니므로 재작성하지 않는다.
+    if (ABSOLUTE_URL_RE.test(target) || DATA_URL_RE.test(target)) return whole;
+    const absPath = resolveAgainstDir(mdDir, target);
+    const url = `${serverUrl}api/local-image?path=${encodeURIComponent(absPath)}`;
+    map.set(url, target);
+    return `${head}${url}${tail}`;
+  });
+  return { body, map };
 }
 
 export function restoreImagePaths(md: string, map: Map<string, string>): string {

--- a/frontend/src/bridge/markora.ts
+++ b/frontend/src/bridge/markora.ts
@@ -1,6 +1,6 @@
 import type { BridgeContext, MarkoraBridge, Theme, UploadResult } from '../types';
 import { splitFrontmatter, joinFrontmatter } from './transform';
-import { collectImageUrlMap, restoreImagePaths } from './imageMap';
+import { rewriteImagePathsForDisplay, restoreImagePaths } from './imageMap';
 
 export function parseQueryContext(href: string): BridgeContext {
   const url = new URL(href);
@@ -38,12 +38,16 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       if (!res.ok) throw new Error(`loadFile failed: ${res.status}`);
       const data = await res.json();
       const { frontmatter, body } = splitFrontmatter(data.content ?? '');
-      // 본문의 상대경로 이미지를 BlockNote가 재작성할 절대 URL로 미리 매핑해 둔다.
-      const baseUri = typeof document !== 'undefined' ? document.baseURI : ctx.serverUrl;
-      for (const [abs, original] of collectImageUrlMap(body, baseUri)) {
-        imageMap.set(abs, original);
+      // 본문의 상대경로 이미지를 디스크에서 서빙되는 local-image URL로 재작성한다.
+      // (그래야 BlockNote <img>가 실제 파일을 가리켜 렌더링됨) 동시에 저장 시 원본
+      // 상대경로로 되돌리기 위한 매핑을 등록한다.
+      const normalized = ctx.filePath.replace(/\\/g, '/');
+      const mdDir = normalized.substring(0, normalized.lastIndexOf('/'));
+      const { body: rewritten, map } = rewriteImagePathsForDisplay(body, mdDir, ctx.serverUrl);
+      for (const [url, original] of map) {
+        imageMap.set(url, original);
       }
-      return { body, frontmatter };
+      return { body: rewritten, frontmatter };
     },
 
     // loadFile과 달리 imageMap을 건드리지 않고 디스크 본문만 반환.


### PR DESCRIPTION
## Summary
- md 파일에 적힌 **상대경로 이미지**(예: `./_assets/x.png`)가 Markora 에디터에서 렌더링되지 않던 문제를 수정합니다.
- **근본 원인**: 로드 시 상대경로를 그대로 BlockNote에 넘기면 `<img src>`가 JCEF 페이지의 base URI(번들 `dist` 디렉터리) 기준으로 해석되어 디스크의 실제 파일이 아닌 엉뚱한 경로(`.../dist/_assets/x.png`)를 가리켜 404 → 렌더링 실패. 붙여넣기 업로드 이미지만 `api/local-image` URL을 생성했고, **로드 시점에 기존 상대경로를 servable URL로 재작성하는 단계가 누락**되어 있었습니다.
- `imageMap.ts`: 저장(역변환) 방향만 처리하던 `collectImageUrlMap`을 제거하고, 로드 방향 `rewriteImagePathsForDisplay(md, mdDir, serverUrl)` 추가 — 상대경로를 `api/local-image?path=<디스크 절대경로>`로 재작성하고 `(URL → 원본 상대경로)` 매핑 반환 (`./`·`../` 해석 포함).
- `markora.ts`: `loadFile()`에서 본문을 재작성된 버전으로 반환하고 매핑을 `imageMap`에 등록. 저장 시 `restoreImagePaths`가 원본 상대경로로 복원하여 **파일은 무손상**으로 유지.

## Test plan
- [x] `npx vitest run` — 프론트엔드 테스트 182개 통과 (신규/갱신 테스트 포함: 상대경로→local-image URL 재작성, `./`·`../` 해석, 절대/data URL 보존, 저장 라운드트립)
- [x] `npm run build` — Vite 번들 빌드 성공
- [x] `./gradlew runIde` 샌드박스에서 `doc/01_General Introduction.md`의 상대경로 이미지 렌더링 육안 확인
- [ ] 다른 문서(`09_Robot Map Service` 등)의 상대경로 이미지도 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)