### PR TITLE
feat(frontend): frontmatter 패널을 기본 접힘으로 렌더링

### DIFF
--- a/frontend/src/editor/FrontmatterPanel.tsx
+++ b/frontend/src/editor/FrontmatterPanel.tsx
@@ -9,16 +9,10 @@ interface Props {
 // 상태는 부모(Editor)가 소유하는 컨트롤드 컴포넌트다.
 export function FrontmatterPanel({ value, onChange }: Props) {
   const hasContent = value.trim() !== '';
+  // 로드된 frontmatter는 접힌 채(▸)로 시작한다. 펼침/접힘은 전적으로 사용자가 제어.
+  // (+ Add frontmatter로 새로 추가할 때는 토글 클릭 자체가 setOpen(true)를 태운다.)
   const [open, setOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  // 파일 로드로 frontmatter가 처음 들어오면 한 번 펼친다. 이후엔 사용자가 토글을 제어.
-  const initializedRef = useRef(false);
-  useEffect(() => {
-    if (!initializedRef.current && value.trim() !== '') {
-      setOpen(true);
-      initializedRef.current = true;
-    }
-  }, [value]);
 
   // 6-dot 메뉴: 바깥 클릭 / Esc 로 닫는다.
   const menuWrapRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/editor/__tests__/FrontmatterPanel.test.tsx
+++ b/frontend/src/editor/__tests__/FrontmatterPanel.test.tsx
@@ -3,8 +3,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { FrontmatterPanel } from '../FrontmatterPanel';
 
 describe('FrontmatterPanel', () => {
-  it('frontmatter가 있으면 펼쳐진 채로 textarea에 inner YAML 표시', () => {
+  it('frontmatter가 있어도 접혀 있어 textarea가 보이지 않고 캐럿/헤더만 보인다', () => {
     render(<FrontmatterPanel value={'title: Post\ntags: [a]'} onChange={() => {}} />);
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByRole('button', { name: /^frontmatter$/i })).toBeTruthy();
+  });
+
+  it('접힌 상태에서 헤더 클릭으로 펼치면 textarea에 inner YAML이 보인다', () => {
+    render(<FrontmatterPanel value={'title: Post\ntags: [a]'} onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /^frontmatter$/i }));
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(ta.value).toBe('title: Post\ntags: [a]');
   });
@@ -18,6 +25,7 @@ describe('FrontmatterPanel', () => {
   it('편집 시 onChange가 새 값으로 호출된다', () => {
     const onChange = vi.fn();
     render(<FrontmatterPanel value={'title: A'} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /^frontmatter$/i }));
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'title: B' } });
     expect(onChange).toHaveBeenCalledWith('title: B');
   });


### PR DESCRIPTION
## Summary
- frontmatter가 있는 `.md` 파일을 열면 Frontmatter 패널이 **접힌 상태(`▸ Frontmatter`)로 시작**하도록 변경
- 파일 로드 시 패널을 자동으로 펼치던 `useEffect`(+ `initializedRef`) 제거 — `open` 초기값(`false`)을 그대로 사용
- `+ Add frontmatter`로 새로 추가하는 흐름은 토글 클릭 자체가 `setOpen(true)`를 태우므로 기존대로 펼쳐져 입력됨
- 외부 편집 등으로 frontmatter가 유입돼도 접힌 상태 유지

## Why
- frontmatter는 보통 메타데이터라 본문 편집 시 시야를 차지하지 않는 편이 자연스러움. 기존에는 열 때마다 펼쳐져 있어 매번 접어야 했음.

## Test plan
- [x] `npm test` — 전체 16개 파일 183개 테스트 통과
- [x] `FrontmatterPanel.test.tsx` 갱신: "있어도 접혀 있어 textarea 미표시", "캐럿 클릭 시 펼쳐져 inner YAML 표시" 추가, "편집 시 onChange"는 펼치는 단계 추가
- [x] sandbox IDE(`./gradlew runIde`)에서 수동 검증: 로드 시 접힘 / 캐럿으로 펼침·편집 / `+ Add frontmatter` 즉시 펼침 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)