### PR TITLE
ci: 릴리스 시 JetBrains Marketplace 자동 업로드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,8 @@ jobs:
         with:
           files: build/distributions/*.zip
           generate_release_notes: true
+
+      - name: Publish to JetBrains Marketplace
+        run: ./gradlew publishPlugin
+        env:
+          JETBRAINS_PUBLISH_TOKEN: ${{ secrets.JETBRAINS_PUBLISH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,13 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
+
+    // 마켓플레이스 업로드는 publishPlugin 태스크가 담당한다.
+    // 토큰은 CI 환경변수 JETBRAINS_PUBLISH_TOKEN으로 주입(GitHub Secret).
+    // channels 미지정 → 기본(Stable), 서명 미설정 → unsigned 업로드(기존 수동 방식과 동일).
+    publishing {
+        token = providers.environmentVariable("JETBRAINS_PUBLISH_TOKEN")
+    }
 }
 
 node {


### PR DESCRIPTION
## Summary
- 태그(`v*`) 푸시로 도는 release 워크플로에 `publishPlugin` 스텝을 추가해 **마켓플레이스 업로드를 자동화**
- 기존 수동 과정(릴리스에서 zip 다운로드 → Marketplace `Upload Update` 다이얼로그 → 파일 선택 → 업로드) 제거

## Changes
- **`build.gradle.kts`**: `intellijPlatform.publishing.token`을 환경변수 `JETBRAINS_PUBLISH_TOKEN`(GitHub Secret)에서 주입. 채널 미지정(=Stable), 서명 미설정(unsigned) — 기존 수동 업로드 방식과 동일
- **`.github/workflows/release.yml`**: GitHub Release 생성 뒤 `./gradlew publishPlugin` 실행 스텝 추가

## Flow (변경 후)
```
make release v0.2.x  →  v* 태그 푸시
   └─ release.yml
        ├─ buildPlugin           (기존)
        ├─ Create GitHub Release (기존, zip 첨부)
        └─ publishPlugin         (추가 → 마켓플레이스 자동 업로드)
```
업로드 후 JetBrains "Under review" 심사는 그대로 유지됨.

## 사전 준비 (완료)
- [x] GitHub Secret `JETBRAINS_PUBLISH_TOKEN` 등록 (JetBrains Marketplace Publish Token)

## Test plan
- [x] `./gradlew publishPlugin --dry-run` (JDK 21) — 빌드 스크립트 파싱 및 `buildPlugin → signPlugin → publishPlugin` 태스크 그래프 정상, BUILD SUCCESSFUL
- [ ] **실제 자동 업로드 검증은 다음 릴리스(예: v0.2.12)부터** — `publishPlugin`은 이미 게시된 버전을 거부하므로 0.2.11로는 재검증 불가
- [ ] 다음 릴리스에서 unsigned 업로드가 거부되면 서명(Secret 3개) 추가로 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)