### PR TITLE
fix: HTML <img> 태그 이미지 렌더링 지원

### DIFF
--- a/frontend/src/bridge/__tests__/imageMap.test.ts
+++ b/frontend/src/bridge/__tests__/imageMap.test.ts
@@ -58,6 +58,76 @@ describe('rewriteImagePathsForDisplay', () => {
   });
 });
 
+describe('rewriteImagePathsForDisplay — HTML <img> 태그', () => {
+  it('상대경로 <img>를 markdown 이미지로 변환하고 htmlMap에 원본 태그를 보관', () => {
+    const tag = '<img src="cover.png" alt="cover" width="75%" />';
+    const { body, htmlMap } = rewriteImagePathsForDisplay(tag, DIR, SERVER);
+    const url =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/doc/cover.png');
+    expect(body).toBe(`![cover](${url})`);
+    expect(htmlMap.get(url)).toBe(tag);
+  });
+
+  it('./ 와 ../ 상대경로 <img>도 디스크 절대경로로 해석', () => {
+    const { htmlMap } = rewriteImagePathsForDisplay(
+      `<img src="./_assets/a.png"> <img src='../b.png'>`,
+      DIR,
+      SERVER,
+    );
+    const urlA =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/doc/_assets/a.png');
+    const urlB =
+      'http://localhost:63342/markora/api/local-image?path=' +
+      encodeURIComponent('/Users/me/b.png');
+    expect(htmlMap.get(urlA)).toBe('<img src="./_assets/a.png">');
+    expect(htmlMap.get(urlB)).toBe(`<img src='../b.png'>`);
+  });
+
+  it('원격/데이터 URL <img>도 렌더되도록 markdown으로 변환(URL은 그대로)하고 태그 보관', () => {
+    const tag = '<img src="https://cdn.example.com/x.png" alt="x">';
+    const { body, htmlMap } = rewriteImagePathsForDisplay(tag, DIR, SERVER);
+    expect(body).toBe('![x](https://cdn.example.com/x.png)');
+    expect(htmlMap.get('https://cdn.example.com/x.png')).toBe(tag);
+  });
+
+  it('src 없는 <img>는 변환하지 않는다', () => {
+    const tag = '<img alt="no src">';
+    const { body, htmlMap } = rewriteImagePathsForDisplay(tag, DIR, SERVER);
+    expect(body).toBe(tag);
+    expect(htmlMap.size).toBe(0);
+  });
+});
+
+describe('restoreImagePaths — HTML <img> 복원', () => {
+  it('htmlMap에 있는 URL은 markdown 이미지 전체를 원본 <img> 태그로 되돌린다(width 무손실)', () => {
+    const tag = '<img src="cover.png" alt="cover" width="75%" />';
+    const url = 'http://localhost:63342/markora/api/local-image?path=%2Fp%2Fcover.png';
+    const htmlMap = new Map([[url, tag]]);
+    expect(restoreImagePaths(`![cover](${url})`, new Map(), htmlMap)).toBe(tag);
+  });
+
+  it('BlockNote가 alt를 바꿔도 URL만 같으면 원본 <img> 태그로 복원', () => {
+    const tag = '<img src="cover.png" width="75%" />';
+    const url = 'http://localhost:63342/markora/api/local-image?path=%2Fp%2Fcover.png';
+    const htmlMap = new Map([[url, tag]]);
+    expect(restoreImagePaths(`![EDITED CAPTION](${url})`, new Map(), htmlMap)).toBe(tag);
+  });
+
+  it('<img> 라운드트립: rewrite → restore === 원본', () => {
+    const original = '문단\n\n<img src="cover.png" alt="cover" width="75%" />\n\n끝\n';
+    const { body, map, htmlMap } = rewriteImagePathsForDisplay(original, DIR, SERVER);
+    expect(restoreImagePaths(body, map, htmlMap)).toBe(original);
+  });
+
+  it('markdown 이미지와 HTML <img>가 섞여도 각각 올바르게 복원', () => {
+    const original = '![md](./a.png)\n\n<img src="b.png" width="50%" />\n';
+    const { body, map, htmlMap } = rewriteImagePathsForDisplay(original, DIR, SERVER);
+    expect(restoreImagePaths(body, map, htmlMap)).toBe(original);
+  });
+});
+
 describe('restoreImagePaths', () => {
   it('직렬화된 절대 URL을 원본 상대경로로 되돌린다', () => {
     const map = new Map([['http://localhost:63342/markora/images/foo.png', 'images/foo.png']]);

--- a/frontend/src/bridge/__tests__/imgHtmlRoundtrip.test.ts
+++ b/frontend/src/bridge/__tests__/imgHtmlRoundtrip.test.ts
@@ -1,0 +1,38 @@
+// HTML <img> 렌더링 + 무손실 저장 엔드투엔드 회귀 테스트.
+// 실제 BlockNote로 parse/serialize 하여, loadFile의 rewrite가 <img>를 렌더 가능한
+// image 블록으로 만들고, saveFile의 restore가 원본 <img>로 무손실 복원하는지 검증한다.
+import { describe, it, expect } from 'vitest';
+import { BlockNoteEditor } from '@blocknote/core';
+import { schema } from '../../editor/schema';
+import { rewriteImagePathsForDisplay, restoreImagePaths } from '../imageMap';
+
+const SERVER = 'http://localhost:63342/markora/';
+const DIR = '/Users/me/doc';
+
+describe('HTML <img> 엔드투엔드 (실제 BlockNote)', () => {
+  it('rewrite한 <img>는 BlockNote에서 image 블록으로 렌더된다', async () => {
+    const editor = BlockNoteEditor.create({ schema } as any);
+    const { body } = rewriteImagePathsForDisplay(
+      '<img src="cover.png" alt="cover" width="75%" />',
+      DIR,
+      SERVER,
+    );
+    const blocks = await editor.tryParseMarkdownToBlocks(body);
+    const img = blocks.find((b: any) => b.type === 'image') as any;
+    expect(img).toBeTruthy();
+    expect(img.props.url).toBe(body.match(/\((.*)\)/)![1]);
+  });
+
+  it('전체 라운드트립: 디스크 <img> → 로드 → BlockNote → 저장 직렬화 → 복원 === 원본', async () => {
+    const editor = BlockNoteEditor.create({ schema } as any);
+    const disk = '# 제목\n\n<img src="cover.png" alt="cover" width="75%" />\n\n본문\n';
+    // 로드: rewrite
+    const { body, map, htmlMap } = rewriteImagePathsForDisplay(disk, DIR, SERVER);
+    // BlockNote in/out (편집 없이 그대로 직렬화)
+    const blocks = await editor.tryParseMarkdownToBlocks(body);
+    const serialized = await editor.blocksToMarkdownLossy(blocks as any);
+    // 저장: restore
+    const restored = restoreImagePaths(serialized, map, htmlMap);
+    expect(restored).toContain('<img src="cover.png" alt="cover" width="75%" />');
+  });
+});

--- a/frontend/src/bridge/imageMap.ts
+++ b/frontend/src/bridge/imageMap.ts
@@ -6,11 +6,19 @@
 // 디스크에서 직접 서빙하는 `api/local-image?path=<절대경로>` URL로 재작성한다.
 // 동시에 (local-image URL → 원본 상대경로) 매핑을 만들어 두고, 저장 시 직렬화된 URL을
 // 원본 상대경로로 되돌려 파일에는 localhost 절대 URL이 박히지 않게 한다.
+//
+// HTML <img> 태그는 추가로 다뤄야 한다: BlockNote의 markdown 파서는 raw HTML <img>를
+// 통째로 버리므로(=렌더 안 됨), 로드 시 <img>를 markdown 이미지 `![alt](url)`로 변환해
+// BlockNote가 image 블록으로 인식하게 한다. 변환과 동시에 (url → 원본 <img> 태그 전체)
+// 매핑(htmlMap)을 만들어, 저장 시 markdown 이미지를 원본 <img> 태그로 되돌린다. 이렇게
+// 하면 width 등 HTML 속성이 무손실로 보존된다.
 
 // `![alt](target)` / `![alt](target "title")`를 head/target/tail 세 그룹으로 나눈다.
 const IMAGE_REWRITE_RE = /(!\[[^\]]*\]\()([^)\s]+)((?:\s+"[^"]*")?\))/g;
-// 링크/이미지의 `](target)` 또는 `](target "title")` 부분.
-const LINK_TARGET_RE = /\]\(([^)\s]+)((?:\s+"[^"]*")?)\)/g;
+// 직렬화된 이미지/링크 `[alt](target "title")`를 그룹으로 나눈다(선행 `!` 포함).
+const FULL_IMAGE_RE = /(!?)\[([^\]]*)\]\(([^)\s]+)((?:\s+"[^"]*")?)\)/g;
+// HTML <img ...> 태그 한 개.
+const HTML_IMG_RE = /<img\b[^>]*>/gi;
 
 const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const DATA_URL_RE = /^data:/i;
@@ -29,27 +37,66 @@ function resolveAgainstDir(dir: string, rel: string): string {
   return parts.join('/');
 }
 
+// <img> 태그에서 속성 값을 뽑는다(쌍/홑따옴표 지원). 없으면 null.
+function getImgAttr(tag: string, name: string): string | null {
+  const re = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i');
+  const m = re.exec(tag);
+  if (!m) return null;
+  return m[1] !== undefined ? m[1] : m[2];
+}
+
+// 상대경로 src를 local-image URL로, 절대/데이터 URL은 그대로 반환.
+function toDisplayUrl(src: string, mdDir: string, serverUrl: string): string {
+  if (ABSOLUTE_URL_RE.test(src) || DATA_URL_RE.test(src)) return src;
+  const absPath = resolveAgainstDir(mdDir, src);
+  return `${serverUrl}api/local-image?path=${encodeURIComponent(absPath)}`;
+}
+
 export function rewriteImagePathsForDisplay(
   md: string,
   mdDir: string,
   serverUrl: string,
-): { body: string; map: Map<string, string> } {
+): { body: string; map: Map<string, string>; htmlMap: Map<string, string> } {
   const map = new Map<string, string>();
-  const body = md.replace(IMAGE_REWRITE_RE, (whole, head: string, target: string, tail: string) => {
-    // 이미 절대 URL이거나 data URL이면 디스크 파일이 아니므로 재작성하지 않는다.
+  const htmlMap = new Map<string, string>();
+
+  // 1) HTML <img>를 markdown 이미지로 변환(BlockNote가 raw <img>를 버리므로 필수).
+  //    저장 시 원본 태그로 되돌리기 위해 (url → 원본 태그 전체)를 htmlMap에 등록.
+  let body = md.replace(HTML_IMG_RE, (tag) => {
+    const src = getImgAttr(tag, 'src');
+    if (!src) return tag; // src 없으면 손대지 않음
+    const url = toDisplayUrl(src, mdDir, serverUrl);
+    const alt = (getImgAttr(tag, 'alt') ?? '').replace(/[\]\n]/g, ' ').trim();
+    htmlMap.set(url, tag);
+    return `![${alt}](${url})`;
+  });
+
+  // 2) markdown 이미지의 상대경로를 local-image URL로 재작성.
+  //    (1)에서 만든 이미지는 이미 절대 URL이라 아래 분기에서 건너뛴다.
+  body = body.replace(IMAGE_REWRITE_RE, (whole, head: string, target: string, tail: string) => {
     if (ABSOLUTE_URL_RE.test(target) || DATA_URL_RE.test(target)) return whole;
     const absPath = resolveAgainstDir(mdDir, target);
     const url = `${serverUrl}api/local-image?path=${encodeURIComponent(absPath)}`;
     map.set(url, target);
     return `${head}${url}${tail}`;
   });
-  return { body, map };
+
+  return { body, map, htmlMap };
 }
 
-export function restoreImagePaths(md: string, map: Map<string, string>): string {
-  if (map.size === 0) return md;
-  return md.replace(LINK_TARGET_RE, (whole, url: string, title: string) => {
-    const original = map.get(url);
-    return original ? `](${original}${title})` : whole;
+export function restoreImagePaths(
+  md: string,
+  map: Map<string, string>,
+  htmlMap?: Map<string, string>,
+): string {
+  if (map.size === 0 && (!htmlMap || htmlMap.size === 0)) return md;
+  return md.replace(FULL_IMAGE_RE, (whole, bang: string, alt: string, target: string, title: string) => {
+    // HTML 유래 이미지: markdown 이미지 전체를 원본 <img> 태그로 복원(width 등 무손실).
+    const tag = bang === '!' ? htmlMap?.get(target) : undefined;
+    if (tag !== undefined) return tag;
+    // markdown 유래 이미지/업로드 이미지: 타깃 경로만 원본으로 복원.
+    const original = map.get(target);
+    if (original !== undefined) return `${bang}[${alt}](${original}${title})`;
+    return whole;
   });
 }

--- a/frontend/src/bridge/markora.ts
+++ b/frontend/src/bridge/markora.ts
@@ -15,6 +15,9 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
   const reloadListeners = new Set<() => void>();
   // (BlockNote가 재작성한 절대 이미지 URL → 원본 경로) 매핑. 저장 시 역변환에 사용.
   const imageMap = new Map<string, string>();
+  // (local-image URL → 원본 HTML <img> 태그 전체) 매핑. 저장 시 markdown 이미지를
+  // 원본 <img>로 되돌려 width 등 속성을 무손실 보존한다.
+  const htmlImageMap = new Map<string, string>();
 
   // Window-level callback Kotlin이 호출
   if (typeof window !== 'undefined') {
@@ -43,9 +46,12 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
       // 상대경로로 되돌리기 위한 매핑을 등록한다.
       const normalized = ctx.filePath.replace(/\\/g, '/');
       const mdDir = normalized.substring(0, normalized.lastIndexOf('/'));
-      const { body: rewritten, map } = rewriteImagePathsForDisplay(body, mdDir, ctx.serverUrl);
+      const { body: rewritten, map, htmlMap } = rewriteImagePathsForDisplay(body, mdDir, ctx.serverUrl);
       for (const [url, original] of map) {
         imageMap.set(url, original);
+      }
+      for (const [url, tag] of htmlMap) {
+        htmlImageMap.set(url, tag);
       }
       return { body: rewritten, frontmatter };
     },
@@ -63,7 +69,7 @@ export function createBridge(ctx: BridgeContext): MarkoraBridge {
     },
 
     async saveFile(body: string, frontmatter: string) {
-      const restored = restoreImagePaths(body, imageMap);
+      const restored = restoreImagePaths(body, imageMap, htmlImageMap);
       const content = joinFrontmatter(frontmatter, restored);
       const res = await fetch(`${ctx.serverUrl}api/file/save`, {
         method: 'POST',


### PR DESCRIPTION
## 문제

md 파일에 HTML `<img src="cover.png">` 형태로 적힌 이미지가 **폴더 위치와 무관하게** 렌더링되지 않았다. (다른 마크다운 에디터에서는 정상)

## 근본 원인

이전에 추가된 상대경로 재작성(`rewriteImagePathsForDisplay`)은 markdown `![]()` 구문만 처리했다. 실제 원인은 폴더 위치가 아니라 **BlockNote의 `tryParseMarkdownToBlocks`가 raw HTML `<img>` 태그를 통째로 버린다**는 점이었다(probe로 확인 — blocks 배열에 아예 포함되지 않음). 따라서 `src`만 재작성해서는 부족하고, `<img>`를 markdown 이미지로 변환해야 image 블록으로 렌더된다.

## 변경

- **로드 시**: `<img src="...">` → `![alt](local-image URL)` 변환 (BlockNote가 image 블록으로 인식 → 렌더)
- **저장 시**: 원본 `<img>` 태그 전체로 복원하여 `width` 등 HTML 속성 **무손실** 보존
  - `rewriteImagePathsForDisplay`가 `htmlMap`(url → 원본 태그) 추가 반환
  - `restoreImagePaths(md, map, htmlMap?)`가 html 유래 이미지를 원본 태그로 복원
- 상대경로/원격·데이터 URL/`src` 없는 태그 등 케이스 처리

## 알려진 한계 (드묾)

- 같은 파일을 markdown `![]()`와 HTML `<img>` 양쪽으로 참조하면 URL 충돌로 둘 다 `<img>`로 복원됨
- BlockNote에서 HTML 이미지 캡션 편집 시 저장 시점에 원본 태그로 덮여 유실

## Test plan

- [x] 단위 테스트 추가 (`imageMap.test.ts` — 변환/복원/라운드트립/혼합)
- [x] 실제 BlockNote 엔드투엔드 테스트 추가 (`imgHtmlRoundtrip.test.ts` — 렌더 + 무손실 라운드트립)
- [x] 전체 프론트엔드 테스트 193개 통과
- [x] vite 프로덕션 번들 빌드 통과
- [x] `runIde` 실제 IDE에서 이미지 5개 렌더링 시각 확인