### PR TITLE
feat: blockquote 내부 리스트(중첩 포함) 지원

### DIFF
--- a/docs/superpowers/plans/2026-06-11-blockquote-list-support.md
+++ b/docs/superpowers/plans/2026-06-11-blockquote-list-support.md
@@ -1,0 +1,574 @@
+# Blockquote 내부 리스트 지원 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** blockquote 안의 bullet/numbered 리스트(중첩 포함)를 markora에서 파싱·렌더·저장 가능하게 한다.
+
+**Architecture:** BlockNote는 top-level 리스트는 완벽히 처리하지만 `>` 내부에서는 평탄화한다. 새 모듈 `blockquote.ts`가 `>` 껍데기를 벗겨 BlockNote에 재위임(파싱)하고 다시 씌운다(직렬화). markora는 `>` 레이어만 책임지고 리스트 처리는 BlockNote를 재활용한다.
+
+**Tech Stack:** TypeScript, BlockNote 0.49 (`@blocknote/core`), Vitest (happy-dom).
+
+---
+
+## File Structure
+
+- **Create** `frontend/src/markdown/blockquote.ts` — 파싱/직렬화 `>` 껍데기 레이어. 순수 헬퍼(`splitRuns`, `stripQuotePrefix`, `assembleQuote`, `serializeQuote`)와 editor를 받는 두 공개 함수(`parseMarkdownWithBlockquotes`, `serializeBlocksWithBlockquotes`).
+- **Create** `frontend/src/markdown/__tests__/blockquote.test.ts` — 단위 + 통합 + 라운드트립 테스트.
+- **Modify** `frontend/src/editor/Editor.tsx` — 3곳(L63, L92, L176)에서 BlockNote 직접 호출을 새 함수로 교체, import 추가.
+
+`customParse.ts`(KaTeX/Mermaid inline)는 변경하지 않는다. `postParse`/`preSerialize`와 합성만 한다.
+
+---
+
+## Task 1: 라인 스캐너 `splitRuns` (코드펜스 인지)
+
+**Files:**
+- Create: `frontend/src/markdown/blockquote.ts`
+- Test: `frontend/src/markdown/__tests__/blockquote.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`frontend/src/markdown/__tests__/blockquote.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { splitRuns } from '../blockquote';
+
+describe('splitRuns', () => {
+  it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
+    const body = 'para\n> q1\n> q2\nafter';
+    expect(splitRuns(body)).toEqual([
+      { kind: 'plain', text: 'para' },
+      { kind: 'quote', text: '> q1\n> q2' },
+      { kind: 'plain', text: 'after' },
+    ]);
+  });
+
+  it('앞 공백 ≤3까지는 blockquote로 인정', () => {
+    expect(splitRuns('   > q')).toEqual([{ kind: 'quote', text: '   > q' }]);
+  });
+
+  it('코드펜스 내부의 > 줄은 blockquote로 오인하지 않음', () => {
+    const body = '```\n> not a quote\n```';
+    expect(splitRuns(body)).toEqual([
+      { kind: 'plain', text: '```\n> not a quote\n```' },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: FAIL — `splitRuns` is not exported / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`frontend/src/markdown/blockquote.ts`:
+
+```ts
+export type Run = { kind: 'quote' | 'plain'; text: string };
+
+const QUOTE_LINE_RE = /^ {0,3}>/;
+const FENCE_RE = /^ {0,3}(```|~~~)/;
+
+// 원문을 줄 단위로 훑어 연속된 blockquote 줄 / 일반 줄 구간(run)으로 나눈다.
+// 코드펜스(``` 또는 ~~~) 내부의 '>' 줄은 blockquote로 오인하지 않는다.
+export function splitRuns(body: string): Run[] {
+  const lines = body.split('\n');
+  const runs: Run[] = [];
+  let cur: Run | null = null;
+  let inFence = false;
+
+  for (const line of lines) {
+    if (FENCE_RE.test(line)) inFence = !inFence;
+    const kind: Run['kind'] = !inFence && QUOTE_LINE_RE.test(line) ? 'quote' : 'plain';
+    if (!cur || cur.kind !== kind) {
+      cur = { kind, text: line };
+      runs.push(cur);
+    } else {
+      cur.text += '\n' + line;
+    }
+  }
+  return runs;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/markdown/blockquote.ts frontend/src/markdown/__tests__/blockquote.test.ts
+git commit -m "feat(blockquote): add splitRuns line scanner with fence awareness"
+```
+
+---
+
+## Task 2: `stripQuotePrefix` — `>` 접두사 1단계 제거
+
+**Files:**
+- Modify: `frontend/src/markdown/blockquote.ts`
+- Test: `frontend/src/markdown/__tests__/blockquote.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`blockquote.test.ts`에 추가:
+
+```ts
+import { splitRuns, stripQuotePrefix } from '../blockquote';
+
+describe('stripQuotePrefix', () => {
+  it('> 와 뒤따르는 공백 1개만 제거하고 들여쓰기는 보존', () => {
+    const text = '> - a\n>   - a1\n>';
+    expect(stripQuotePrefix(text)).toBe('- a\n  - a1\n');
+  });
+
+  it('> 없는 줄은 그대로', () => {
+    expect(stripQuotePrefix('plain')).toBe('plain');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: FAIL — `stripQuotePrefix` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`blockquote.ts`에 추가:
+
+```ts
+// 각 줄에서 blockquote 마커 1단계('>' + 공백 1개)만 제거한다.
+// 나머지 들여쓰기는 보존되어 중첩 리스트 구조가 유지된다.
+// '>' 단독 줄은 빈 줄이 된다. 중첩 blockquote('>>')는 1단계만 벗겨 내부 '>'가 남는다(의도적).
+export function stripQuotePrefix(text: string): string {
+  return text
+    .split('\n')
+    .map(line => {
+      const m = line.match(/^ {0,3}>( ?)(.*)$/);
+      return m ? m[2] : line;
+    })
+    .join('\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/markdown/blockquote.ts frontend/src/markdown/__tests__/blockquote.test.ts
+git commit -m "feat(blockquote): add stripQuotePrefix"
+```
+
+---
+
+## Task 3: `parseMarkdownWithBlockquotes` — 파싱 + quote 조립
+
+**Files:**
+- Modify: `frontend/src/markdown/blockquote.ts`
+- Test: `frontend/src/markdown/__tests__/blockquote.test.ts`
+
+조립 규칙: 벗긴 내부를 BlockNote로 재파싱한 뒤, 첫 블록이 `paragraph`면 그 인라인 content를 `quote.content`(선행 단락)로, 나머지를 `quote.children`로. 첫 블록이 paragraph가 아니면 `content=[]`, 전부 children. 빈 plain run(공백/개행뿐)은 건너뛴다(빈 paragraph 주입 방지).
+
+- [ ] **Step 1: Write the failing test**
+
+`blockquote.test.ts`에 추가:
+
+```ts
+import { BlockNoteEditor } from '@blocknote/core';
+import { schema } from '../../editor/schema';
+import {
+  splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes,
+} from '../blockquote';
+
+describe('parseMarkdownWithBlockquotes', () => {
+  it('> - a / > - b 를 quote + bullet children 로 파싱', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> - a\n> - b');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].children.map((c: any) => c.type))
+      .toEqual(['bulletListItem', 'bulletListItem']);
+  });
+
+  it('선행 단락 + 리스트: 단락은 content, 리스트는 children', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const md = '> 링크\n>\n> - 범위\n> - 근거';
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, md);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].content[0].text).toBe('링크');
+    expect(blocks[0].children).toHaveLength(2);
+    expect(blocks[0].children[0].type).toBe('bulletListItem');
+  });
+
+  it('numbered list 지원', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> 1. a\n> 2. b');
+    expect(blocks[0].children[0].type).toBe('numberedListItem');
+  });
+
+  it('중첩 리스트 지원', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> - a\n>   - a1');
+    const top = blocks[0].children[0];
+    expect(top.type).toBe('bulletListItem');
+    expect(top.children[0].type).toBe('bulletListItem');
+  });
+
+  it('blockquote 없는 문서는 BlockNote 기본 파싱과 동일하게 동작', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '# T\n\n- a\n- b');
+    expect(blocks.map((b: any) => b.type))
+      .toEqual(['heading', 'bulletListItem', 'bulletListItem']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: FAIL — `parseMarkdownWithBlockquotes` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`blockquote.ts`에 추가:
+
+```ts
+import type { BlockNoteEditor } from '@blocknote/core';
+
+type AnyBlock = { type: string; props?: Record<string, any>; content?: any; children?: AnyBlock[] };
+
+const QUOTE_PROPS = { backgroundColor: 'default', textColor: 'default' } as const;
+
+// 벗긴 내부 블록 배열을 단일 quote 블록으로 조립한다.
+function assembleQuote(innerBlocks: AnyBlock[]): AnyBlock {
+  let content: any[] = [];
+  let children: AnyBlock[] = innerBlocks;
+  if (innerBlocks.length > 0 && innerBlocks[0].type === 'paragraph') {
+    content = (innerBlocks[0].content as any[]) ?? [];
+    children = innerBlocks.slice(1);
+  }
+  return { type: 'quote', props: { ...QUOTE_PROPS }, content, children };
+}
+
+// 원문 마크다운을 파싱하되 blockquote 구간은 '>'를 벗겨 BlockNote에 재위임 후 quote로 조립한다.
+export async function parseMarkdownWithBlockquotes(
+  editor: BlockNoteEditor<any, any, any>,
+  body: string,
+): Promise<AnyBlock[]> {
+  const out: AnyBlock[] = [];
+  for (const run of splitRuns(body)) {
+    if (run.kind === 'plain') {
+      if (run.text.trim() === '') continue; // 빈 분리 run은 빈 paragraph 주입을 피하려 건너뛴다
+      const blocks = (await editor.tryParseMarkdownToBlocks(run.text)) as AnyBlock[];
+      out.push(...blocks);
+    } else {
+      const inner = stripQuotePrefix(run.text);
+      const innerBlocks = (await editor.tryParseMarkdownToBlocks(inner)) as AnyBlock[];
+      out.push(assembleQuote(innerBlocks));
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/markdown/blockquote.ts frontend/src/markdown/__tests__/blockquote.test.ts
+git commit -m "feat(blockquote): parse blockquote-with-list via re-delegation to BlockNote"
+```
+
+---
+
+## Task 4: `serializeBlocksWithBlockquotes` — `>` 접두사 복원
+
+**Files:**
+- Modify: `frontend/src/markdown/blockquote.ts`
+- Test: `frontend/src/markdown/__tests__/blockquote.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`blockquote.test.ts`에 추가:
+
+```ts
+import {
+  splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes,
+  serializeBlocksWithBlockquotes,
+} from '../blockquote';
+
+describe('serializeBlocksWithBlockquotes', () => {
+  it('quote + children 를 > 접두사 붙은 리스트로 직렬화', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = [{
+      type: 'quote',
+      props: { backgroundColor: 'default', textColor: 'default' },
+      content: [{ type: 'text', text: '링크', styles: {} }],
+      children: [
+        { type: 'bulletListItem', content: [{ type: 'text', text: 'a', styles: {} }] },
+        { type: 'bulletListItem', content: [{ type: 'text', text: 'b', styles: {} }] },
+      ],
+    }];
+    const md = await serializeBlocksWithBlockquotes(editor, blocks);
+    expect(md).toContain('> 링크');
+    expect(md).toContain('> * a');
+    expect(md).toContain('> * b');
+    // 리스트 줄이 blockquote 밖으로 탈출하지 않는다
+    expect(md).not.toMatch(/^\* a/m);
+  });
+
+  it('children 없는 일반 quote 는 기존처럼 직렬화', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = [{
+      type: 'quote',
+      props: { backgroundColor: 'default', textColor: 'default' },
+      content: [{ type: 'text', text: 'hello', styles: {} }],
+      children: [],
+    }];
+    const md = await serializeBlocksWithBlockquotes(editor, blocks);
+    expect(md.trim()).toBe('> hello');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: FAIL — `serializeBlocksWithBlockquotes` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`blockquote.ts`에 추가:
+
+```ts
+// 단일 quote 블록을 직렬화한다. lead(선행 단락)와 children(리스트)를 각각 BlockNote로
+// 직렬화한 뒤 children 모든 줄에 '> ' 접두사를 다시 입혀 합친다.
+async function serializeQuote(
+  editor: BlockNoteEditor<any, any, any>,
+  quote: AnyBlock,
+): Promise<string> {
+  const children = quote.children ?? [];
+  const hasContent = Array.isArray(quote.content) && quote.content.length > 0;
+  const lead = hasContent
+    ? (await editor.blocksToMarkdownLossy([{ ...quote, children: [] }] as any)).trimEnd()
+    : '';
+  if (children.length === 0) return lead || '>';
+  const childMd = (await editor.blocksToMarkdownLossy(children as any)).trimEnd();
+  const prefixed = childMd
+    .split('\n')
+    .map(l => (l.length ? `> ${l}` : '>'))
+    .join('\n');
+  return lead ? `${lead}\n>\n${prefixed}` : prefixed;
+}
+
+// 블록 트리를 마크다운으로 직렬화하되 quote 블록만 '>' 접두사 복원을 거친다.
+// 인접한 비-quote 블록은 묶어서 한 번에 BlockNote로 직렬화한다.
+export async function serializeBlocksWithBlockquotes(
+  editor: BlockNoteEditor<any, any, any>,
+  blocks: AnyBlock[],
+): Promise<string> {
+  const parts: string[] = [];
+  let buffer: AnyBlock[] = [];
+  const flush = async () => {
+    if (buffer.length === 0) return;
+    parts.push((await editor.blocksToMarkdownLossy(buffer as any)).trimEnd());
+    buffer = [];
+  };
+  for (const block of blocks) {
+    if (block.type === 'quote') {
+      await flush();
+      parts.push(await serializeQuote(editor, block));
+    } else {
+      buffer.push(block);
+    }
+  }
+  await flush();
+  return parts.join('\n\n') + '\n';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/markdown/blockquote.ts frontend/src/markdown/__tests__/blockquote.test.ts
+git commit -m "feat(blockquote): serialize quote children with > prefix restoration"
+```
+
+---
+
+## Task 5: 라운드트립 + 무회귀 테스트
+
+**Files:**
+- Test: `frontend/src/markdown/__tests__/blockquote.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`blockquote.test.ts`에 추가. `postParse`/`preSerialize` 합성을 포함해 Editor.tsx 실제 경로를 모사한다:
+
+```ts
+import { postParse, preSerialize } from '../customParse';
+
+async function roundtrip(md: string): Promise<any[]> {
+  const editor = BlockNoteEditor.create({ schema });
+  const parsed = postParse(await parseMarkdownWithBlockquotes(editor, md) as any);
+  editor.replaceBlocks(editor.document, parsed as any);
+  const out = await serializeBlocksWithBlockquotes(editor, preSerialize(editor.document as any) as any);
+  // 두 번째 파싱
+  const editor2 = BlockNoteEditor.create({ schema });
+  return postParse(await parseMarkdownWithBlockquotes(editor2, out) as any) as any[];
+}
+
+describe('blockquote 라운드트립', () => {
+  it('선행 단락 + 리스트 구조가 md→blocks→md→blocks 후 보존', async () => {
+    const md = '> 링크\n>\n> - 범위\n> - 근거';
+    const blocks: any = await roundtrip(md);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].content[0].text).toBe('링크');
+    expect(blocks[0].children.map((c: any) => c.type))
+      .toEqual(['bulletListItem', 'bulletListItem']);
+  });
+
+  it('중첩 리스트가 라운드트립 후 보존', async () => {
+    const blocks: any = await roundtrip('> - a\n>   - a1');
+    expect(blocks[0].children[0].children[0].type).toBe('bulletListItem');
+  });
+
+  it('코드펜스 내부 > 줄은 quote 로 변하지 않는다', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '```\n> x\n```');
+    expect(blocks[0].type).toBe('codeBlock');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `npx vitest run src/markdown/__tests__/blockquote.test.ts`
+Expected: 모두 PASS여야 한다. FAIL이면 직렬화 출력 형태(`> *` 접두사/빈 줄 처리)를 디버깅한다 — `console.log(out)`로 중간 마크다운을 확인하고 Task 4의 `serializeQuote` 결합 규칙을 점검한다.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/markdown/__tests__/blockquote.test.ts
+git commit -m "test(blockquote): round-trip and fence-safety tests"
+```
+
+---
+
+## Task 6: Editor.tsx 통합
+
+**Files:**
+- Modify: `frontend/src/editor/Editor.tsx` (import 추가; L63, L176, L92 교체)
+
+- [ ] **Step 1: import 추가**
+
+`Editor.tsx` 상단 import 블록(현재 L7 부근)에 추가:
+
+```ts
+import { parseMarkdownWithBlockquotes, serializeBlocksWithBlockquotes } from '../markdown/blockquote';
+```
+
+- [ ] **Step 2: 로드 경로 교체 (L63)**
+
+기존:
+```ts
+        const blocks = await editor.tryParseMarkdownToBlocks(body);
+        editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
+```
+교체:
+```ts
+        const blocks = await parseMarkdownWithBlockquotes(editor, body);
+        editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
+```
+
+- [ ] **Step 3: 리로드 경로 교체 (L176 부근, 동일 패턴)**
+
+기존:
+```ts
+        const blocks = await editor.tryParseMarkdownToBlocks(body);
+        editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
+```
+교체:
+```ts
+        const blocks = await parseMarkdownWithBlockquotes(editor, body);
+        editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
+```
+
+- [ ] **Step 4: 저장 경로 교체 (L92)**
+
+기존:
+```ts
+        const body = await editor.blocksToMarkdownLossy(preSerialize(editor.document as any) as any);
+```
+교체:
+```ts
+        const body = await serializeBlocksWithBlockquotes(editor, preSerialize(editor.document as any) as any);
+```
+
+- [ ] **Step 5: 타입 체크 + 전체 프론트 테스트**
+
+Run: `npx tsc --noEmit -p frontend/tsconfig.json` (실패 시 `cd frontend && npx tsc --noEmit`)
+Expected: 에러 없음.
+
+Run: `cd frontend && npx vitest run`
+Expected: blockquote.test.ts + 기존 integration/roundtrip/saveGuard/inline-roundtrip 전부 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/editor/Editor.tsx
+git commit -m "feat(blockquote): wire blockquote-aware parse/serialize into Editor"
+```
+
+---
+
+## Task 7: 빌드 + 육안 검증
+
+**Files:** 없음(검증만)
+
+- [ ] **Step 1: 프론트엔드 번들 빌드**
+
+Run: `./gradlew buildFrontend` (markora/ 루트에서)
+Expected: BUILD SUCCESSFUL, `src/main/resources/blocknote/dist/` 갱신.
+
+- [ ] **Step 2: (가능 시) 샌드박스 IDE 육안 확인**
+
+Run: `./gradlew runIde`
+이미지 케이스(`> 링크` + `> - 항목...`) .md 파일을 열어 blockquote 안에 리스트가 마커와 함께 렌더되는지, 저장 후 재오픈 시 구조가 보존되는지 확인.
+
+- [ ] **Step 3: 최종 커밋(필요 시 번들 산출물)**
+
+번들 산출물이 git 추적 대상이면:
+```bash
+git add -A
+git commit -m "build(blockquote): rebuild frontend bundle"
+```
+아니면 스킵.
+
+---
+
+## 완료 기준
+
+- `blockquote.test.ts` 전체 PASS + 기존 테스트 무회귀
+- `npx tsc --noEmit` 클린
+- `./gradlew buildFrontend` 성공
+- (가능 시) runIde 육안 확인: 파싱·렌더·저장 라운드트립

--- a/docs/superpowers/specs/2026-06-11-blockquote-list-support-design.md
+++ b/docs/superpowers/specs/2026-06-11-blockquote-list-support-design.md
@@ -1,0 +1,136 @@
+# Blockquote 내부 리스트 지원 설계
+
+날짜: 2026-06-11
+대상 저장소: `markora/`
+브랜치: `feature/blockquote-list-support`
+
+## 배경 / 문제
+
+다른 마크다운 에디터는 blockquote 안에 리스트를 넣는 형태(`> - item`)를 지원하지만, markora는 이를 평문으로 뭉개버린다.
+
+원인은 markora 코드가 아니라 **BlockNote 내장 마크다운 파서/직렬화기의 한계**다 (0.49.0, 0.51.4 모두 동일하게 재현 확인됨):
+
+1. **파싱** (`tryParseMarkdownToBlocks`): `> - item` 입력 시 리스트 구조를 버리고 단일 `quote` 블록의 flat inline 텍스트로 합친다. `- ` 마커 소실, `children: []`.
+2. **직렬화** (`blocksToMarkdownLossy`): `quote` + list children 구조를 만들어줘도 list가 `> ` 접두사 없이 출력되어 blockquote 밖으로 탈출한다.
+
+BlockNote 업그레이드로는 해결되지 않으므로 markora 측에서 커스텀 파싱/직렬화 레이어를 둔다.
+
+## 핵심 통찰
+
+BlockNote는 **top-level에서는 리스트(중첩 포함)를 완벽히 파싱/직렬화**한다. 망가지는 건 오직 `>` 안에 있을 때다. 따라서 "`>` 껍데기를 벗기고 BlockNote에게 맡긴 뒤 다시 씌우는" 전략으로, BlockNote의 검증된 리스트 처리를 양방향 모두 재활용한다. markora는 `>` 껍데기 레이어만 책임진다.
+
+## 범위
+
+| 항목 | 결정 |
+|------|------|
+| 리스트 종류 | bullet + numbered list |
+| blockquote 내부 구성 | 선행 단락(1개) + 리스트 |
+| 리스트 중첩 | 중첩 리스트까지 재귀 지원 |
+| 중첩 blockquote(`>>`) | 범위 외 — 1단계만 처리, 나머지는 기존처럼 평탄화 (의도적) |
+| 리스트 뒤 후행 단락 / 임의 블록 시퀀스 | 범위 외 |
+
+## 아키텍처 / 통합 지점
+
+새 모듈 **`frontend/src/markdown/blockquote.ts`** 를 추가한다. export 2개:
+
+- `parseMarkdownWithBlockquotes(editor, body): Promise<Block[]>` — 원문 마크다운에서 blockquote 구간을 직접 처리하며 블록 트리 반환
+- `serializeBlocksWithBlockquotes(editor, blocks): Promise<string>` — 블록 트리에서 quote+children를 `>` 접두사로 복원하며 마크다운 반환
+
+두 함수 모두 내부적으로 `editor.tryParseMarkdownToBlocks` / `editor.blocksToMarkdownLossy`를 재사용한다. 직접 구현하는 것은 `>` 껍데기 레이어뿐이다.
+
+`customParse.ts`의 `postParse` / `preSerialize`(KaTeX·Mermaid)는 그대로 유지하고 기존 위치에서 합성한다. blockquote는 별개 관심사이므로 customParse.ts에 합치지 않고 모듈을 분리한다.
+
+### `Editor.tsx` 변경 (3곳)
+
+- L63, L176 (로드 / 외부변경 리로드):
+  `editor.tryParseMarkdownToBlocks(body)` → `parseMarkdownWithBlockquotes(editor, body)`
+  (이후 `postParse(...)` 적용은 그대로)
+- L92 (저장):
+  `editor.blocksToMarkdownLossy(preSerialize(editor.document))` → `serializeBlocksWithBlockquotes(editor, preSerialize(editor.document))`
+
+합성 순서:
+- 파싱: `postParse(await parseMarkdownWithBlockquotes(editor, body))`
+- 저장: `await serializeBlocksWithBlockquotes(editor, preSerialize(editor.document))`
+
+`postParse`가 children까지 재귀하므로 quote 내부 리스트 항목의 인라인 수식도 자연스럽게 처리된다.
+
+## 파싱 알고리즘
+
+`parseMarkdownWithBlockquotes(editor, body)`:
+
+### 1단계 — 구간 분할 (라인 스캐너)
+
+원문을 줄 단위로 훑으며 두 종류의 연속 구간(run)으로 나눈다:
+- **blockquote run**: 앞 공백(≤3) 다음 `>`로 시작하는 줄들의 연속 구간
+- **일반 run**: 그 외
+
+코드펜스 인지: ` ``` ` 또는 `~~~` 토글 상태를 추적해 **펜스 내부의 `>` 줄은 blockquote로 오인하지 않는다**. 펜스 안은 무조건 일반 run에 귀속.
+
+### 2단계 — run별 파싱
+
+- **일반 run**: `editor.tryParseMarkdownToBlocks(runText)` 그대로
+- **blockquote run**:
+  1. 각 줄에서 `>` 접두사 1단계 제거 (`> x` → `x`, `>` → 빈 줄). 들여쓰기는 보존 → 중첩 list 유지
+  2. 벗긴 내부 텍스트를 `editor.tryParseMarkdownToBlocks(inner)`로 재파싱 → 정상 블록 배열
+  3. **조립 규칙**: 첫 블록이 `paragraph`면 그 인라인 content를 `quote.content`(선행 단락)로 쓰고 나머지 블록을 `quote.children`로. 첫 블록이 paragraph가 아니면(예: 바로 list 시작) `quote.content`는 빈 배열, 전부 children으로.
+  4. 결과: `{ type: 'quote', props, content, children }` 단일 블록
+
+### 3단계 — 이어붙이기
+
+모든 run의 블록을 원래 순서대로 concat.
+
+## 직렬화 알고리즘
+
+`serializeBlocksWithBlockquotes(editor, blocks)`:
+
+최상위 블록을 순회하며 **quote 블록만 특별 처리**하고 나머지는 BlockNote에 위임한다. 인접한 비-quote 블록들은 묶어서 한 번에 직렬화해 블록 간 간격을 BlockNote 기본값대로 유지한다.
+
+**quote 블록 직렬화** (children 유무 무관하게 일관 처리):
+1. **lead**: `editor.blocksToMarkdownLossy([{...quote, children: []}])` → `> 링크` (BlockNote가 `>` 부착)
+2. **children**: children이 있으면 `editor.blocksToMarkdownLossy(children)` → `* 항목 1\n* 항목 2` (중첩 들여쓰기 보존)
+3. **`>` 재적용**: children 마크다운의 모든 줄 앞에 `> ` 부착 (빈 줄은 `>`로). 중첩 들여쓰기는 텍스트로 보존 → `>   * 하위항목`
+4. **결합**: `lead` + `\n>\n` + `prefixed-children`. children이 없으면 lead만 출력.
+
+결과 예:
+```
+> 링크
+>
+> * 항목 1
+> * 항목 2
+```
+
+이 출력을 다시 `parseMarkdownWithBlockquotes`로 읽으면 `>` 벗겨 → `* 항목` → list 재파싱 → 동일 구조 복원. **라운드트립 성립.**
+
+구현은 별도 임시 에디터 없이 현재 `editor` 인스턴스의 `blocksToMarkdownLossy`를 부분 호출(서브트리/단일 블록 단위). 동작 검증은 테스트로 한다.
+
+## 엣지케이스
+
+- **코드펜스 안 `>`**: fence 토글 추적으로 blockquote 오인 방지
+- **`>` 없는 일반 문서**: blockquote run 0개 → 전부 일반 run → 기존과 100% 동일 동작 (무회귀)
+- **`> 단락`만 있고 list 없음**: children 없는 quote → 기존 동작 유지
+- **빈 quote 줄(`>`)**: 선행/내부 빈 줄로 보존
+- **중첩 blockquote(`>>`)**: 1단계만 처리, 나머지 평탄화 (범위 외, 의도적)
+
+## 라운드트립 안전성 (saveGuard)
+
+기존 `saveGuard.ts`의 `checkSaveSafety`는 직렬화 결과의 손실을 검출한다. 새 직렬화 경로가 이 검사를 통과해야 하므로 **"파싱→직렬화→재파싱이 동일 블록 트리를 내는지"를 테스트로 명시 검증**한다. quote+list가 saveGuard에 손실로 오탐되지 않는지도 확인한다.
+
+## 테스트
+
+신규 `src/markdown/__tests__/blockquote.test.ts` (Vitest):
+
+1. 파싱: `> - a\n> - b` → quote(children=[bullet, bullet]), 마커 보존
+2. 파싱: 선행 단락 + list (이미지 케이스) → quote.content=링크, children=4개 항목
+3. 파싱: numbered list (`> 1. a`) → numberedListItem children
+4. 파싱: 중첩 list (`> - a\n>   - a1`) → 중첩 children
+5. 직렬화: quote+children → `> * a\n> * b` 형태, `>` 접두사 유지
+6. 라운드트립: 위 케이스 md→blocks→md→blocks 동일성
+7. 코드펜스 안 `>` 줄이 quote로 안 변하는지
+8. blockquote 없는 일반 문서 무회귀
+9. 기존 `integration.test.ts` / `roundtrip.test.ts` 전부 통과 유지
+
+## 완료 기준
+
+- 위 테스트 통과
+- `./gradlew buildFrontend` 성공
+- (가능하면) `runIde`로 이미지 케이스 육안 확인

--- a/frontend/src/editor/Editor.tsx
+++ b/frontend/src/editor/Editor.tsx
@@ -5,6 +5,7 @@ import '@blocknote/mantine/style.css';
 import type { MarkoraBridge, Theme } from '../types';
 import { schema } from './schema';
 import { postParse, preSerialize, splitInlineMath } from '../markdown/customParse';
+import { parseMarkdownWithBlockquotes, serializeBlocksWithBlockquotes } from '../markdown/blockquote';
 import { checkSaveSafety } from '../markdown/saveGuard';
 import { reinitOnThemeChange } from '../blocks/MermaidBlock';
 import { handleLineNavigationKeydown } from './lineNavigation';
@@ -60,7 +61,7 @@ export function Editor({ bridge }: Props) {
         if (cancelled) return;
         setFrontmatter(fm);
         frontmatterRef.current = fm;
-        const blocks = await editor.tryParseMarkdownToBlocks(body);
+        const blocks = await parseMarkdownWithBlockquotes(editor, body);
         editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
         lastKnownContentRef.current = body;
         isDirtyRef.current = false;
@@ -89,7 +90,7 @@ export function Editor({ bridge }: Props) {
       saveTimerRef.current = null;
       try {
         setStatus('Saving...');
-        const body = await editor.blocksToMarkdownLossy(preSerialize(editor.document as any) as any);
+        const body = await serializeBlocksWithBlockquotes(editor, preSerialize(editor.document as any) as any);
         // 저장 직전 디스크 현재 본문을 부작용 없이 읽어 외부 편집(터미널 등)을 확인한다.
         let disk: string | undefined;
         try { disk = await bridge.peekFile(); } catch { disk = undefined; }
@@ -173,7 +174,7 @@ export function Editor({ bridge }: Props) {
         // reload가 트리거하는 onChange를 user edit으로 오인해 되저장하지 않도록 억제.
         // (loadedRef와 동일한 패턴: replaceBlocks 동안 플래그 on, 다음 tick에 off)
         applyingRemoteRef.current = true;
-        const blocks = await editor.tryParseMarkdownToBlocks(body);
+        const blocks = await parseMarkdownWithBlockquotes(editor, body);
         editor.replaceBlocks(editor.document, postParse(blocks as any) as any);
         lastKnownContentRef.current = body;
         isDirtyRef.current = false;

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { splitRuns } from '../blockquote';
+
+describe('splitRuns', () => {
+  it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
+    const body = 'para\n> q1\n> q2\nafter';
+    expect(splitRuns(body)).toEqual([
+      { kind: 'plain', text: 'para' },
+      { kind: 'quote', text: '> q1\n> q2' },
+      { kind: 'plain', text: 'after' },
+    ]);
+  });
+
+  it('앞 공백 ≤3까지는 blockquote로 인정', () => {
+    expect(splitRuns('   > q')).toEqual([{ kind: 'quote', text: '   > q' }]);
+  });
+
+  it('코드펜스 내부의 > 줄은 blockquote로 오인하지 않음', () => {
+    const body = '```\n> not a quote\n```';
+    expect(splitRuns(body)).toEqual([
+      { kind: 'plain', text: '```\n> not a quote\n```' },
+    ]);
+  });
+});

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { splitRuns, stripQuotePrefix } from '../blockquote';
+import { BlockNoteEditor } from '@blocknote/core';
+import { schema } from '../../editor/schema';
+import { splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes } from '../blockquote';
 
 describe('splitRuns', () => {
   it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
@@ -31,5 +33,47 @@ describe('stripQuotePrefix', () => {
 
   it('> 없는 줄은 그대로', () => {
     expect(stripQuotePrefix('plain')).toBe('plain');
+  });
+});
+
+describe('parseMarkdownWithBlockquotes', () => {
+  it('> - a / > - b 를 quote + bullet children 로 파싱', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> - a\n> - b');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].children.map((c: any) => c.type))
+      .toEqual(['bulletListItem', 'bulletListItem']);
+  });
+
+  it('선행 단락 + 리스트: 단락은 content, 리스트는 children', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const md = '> 링크\n>\n> - 범위\n> - 근거';
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, md);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].content[0].text).toBe('링크');
+    expect(blocks[0].children).toHaveLength(2);
+    expect(blocks[0].children[0].type).toBe('bulletListItem');
+  });
+
+  it('numbered list 지원', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> 1. a\n> 2. b');
+    expect(blocks[0].children[0].type).toBe('numberedListItem');
+  });
+
+  it('중첩 리스트 지원', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> - a\n>   - a1');
+    const top = blocks[0].children[0];
+    expect(top.type).toBe('bulletListItem');
+    expect(top.children[0].type).toBe('bulletListItem');
+  });
+
+  it('blockquote 없는 문서는 BlockNote 기본 파싱과 동일하게 동작', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '# T\n\n- a\n- b');
+    expect(blocks.map((b: any) => b.type))
+      .toEqual(['heading', 'bulletListItem', 'bulletListItem']);
   });
 });

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { splitRuns } from '../blockquote';
+import { splitRuns, stripQuotePrefix } from '../blockquote';
 
 describe('splitRuns', () => {
   it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
@@ -20,5 +20,16 @@ describe('splitRuns', () => {
     expect(splitRuns(body)).toEqual([
       { kind: 'plain', text: '```\n> not a quote\n```' },
     ]);
+  });
+});
+
+describe('stripQuotePrefix', () => {
+  it('> 와 뒤따르는 공백 1개만 제거하고 들여쓰기는 보존', () => {
+    const text = '> - a\n>   - a1\n>';
+    expect(stripQuotePrefix(text)).toBe('- a\n  - a1\n');
+  });
+
+  it('> 없는 줄은 그대로', () => {
+    expect(stripQuotePrefix('plain')).toBe('plain');
   });
 });

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -38,6 +38,10 @@ describe('stripQuotePrefix', () => {
   it('> 없는 줄은 그대로', () => {
     expect(stripQuotePrefix('plain')).toBe('plain');
   });
+
+  it('> 뒤 탭 1개도 제거', () => {
+    expect(stripQuotePrefix('>\t- a')).toBe('- a');
+  });
 });
 
 describe('parseMarkdownWithBlockquotes', () => {
@@ -72,6 +76,27 @@ describe('parseMarkdownWithBlockquotes', () => {
     const top = blocks[0].children[0];
     expect(top.type).toBe('bulletListItem');
     expect(top.children[0].type).toBe('bulletListItem');
+  });
+
+  it('CRLF 줄바꿈도 LF 와 동일하게 quote + bullet children 로 파싱', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> - a\r\n> - b');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].children.map((c: any) => c.type))
+      .toEqual(['bulletListItem', 'bulletListItem']);
+  });
+
+  it('빈 줄로 구분된 두 quote 는 별개의 quote 블록', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '> a\n\n> b');
+    expect(blocks.map((b: any) => b.type)).toEqual(['quote', 'quote']);
+  });
+
+  it('빈 입력은 빈 배열', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '');
+    expect(blocks).toEqual([]);
   });
 
   it('blockquote 없는 문서는 BlockNote 기본 파싱과 동일하게 동작', async () => {

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { BlockNoteEditor } from '@blocknote/core';
 import { schema } from '../../editor/schema';
-import { splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes } from '../blockquote';
+import {
+  splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes,
+  serializeBlocksWithBlockquotes,
+} from '../blockquote';
 
 describe('splitRuns', () => {
   it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
@@ -75,5 +78,38 @@ describe('parseMarkdownWithBlockquotes', () => {
     const blocks: any = await parseMarkdownWithBlockquotes(editor, '# T\n\n- a\n- b');
     expect(blocks.map((b: any) => b.type))
       .toEqual(['heading', 'bulletListItem', 'bulletListItem']);
+  });
+});
+
+describe('serializeBlocksWithBlockquotes', () => {
+  it('quote + children 를 > 접두사 붙은 리스트로 직렬화', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = [{
+      type: 'quote',
+      props: { backgroundColor: 'default', textColor: 'default' },
+      content: [{ type: 'text', text: '링크', styles: {} }],
+      children: [
+        { type: 'bulletListItem', content: [{ type: 'text', text: 'a', styles: {} }] },
+        { type: 'bulletListItem', content: [{ type: 'text', text: 'b', styles: {} }] },
+      ],
+    }];
+    const md = await serializeBlocksWithBlockquotes(editor, blocks);
+    expect(md).toContain('> 링크');
+    expect(md).toContain('> * a');
+    expect(md).toContain('> * b');
+    // 리스트 줄이 blockquote 밖으로 탈출하지 않는다
+    expect(md).not.toMatch(/^\* a/m);
+  });
+
+  it('children 없는 일반 quote 는 기존처럼 직렬화', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = [{
+      type: 'quote',
+      props: { backgroundColor: 'default', textColor: 'default' },
+      content: [{ type: 'text', text: 'hello', styles: {} }],
+      children: [],
+    }];
+    const md = await serializeBlocksWithBlockquotes(editor, blocks);
+    expect(md.trim()).toBe('> hello');
   });
 });

--- a/frontend/src/markdown/__tests__/blockquote.test.ts
+++ b/frontend/src/markdown/__tests__/blockquote.test.ts
@@ -5,6 +5,7 @@ import {
   splitRuns, stripQuotePrefix, parseMarkdownWithBlockquotes,
   serializeBlocksWithBlockquotes,
 } from '../blockquote';
+import { postParse, preSerialize } from '../customParse';
 
 describe('splitRuns', () => {
   it('blockquote 줄과 일반 줄을 연속 구간으로 분리', () => {
@@ -111,5 +112,37 @@ describe('serializeBlocksWithBlockquotes', () => {
     }];
     const md = await serializeBlocksWithBlockquotes(editor, blocks);
     expect(md.trim()).toBe('> hello');
+  });
+});
+
+async function roundtrip(md: string): Promise<any[]> {
+  const editor = BlockNoteEditor.create({ schema });
+  const parsed = postParse(await parseMarkdownWithBlockquotes(editor, md) as any);
+  editor.replaceBlocks(editor.document, parsed as any);
+  const out = await serializeBlocksWithBlockquotes(editor, preSerialize(editor.document as any) as any);
+  // 두 번째 파싱
+  const editor2 = BlockNoteEditor.create({ schema });
+  return postParse(await parseMarkdownWithBlockquotes(editor2, out) as any) as any[];
+}
+
+describe('blockquote 라운드트립', () => {
+  it('선행 단락 + 리스트 구조가 md→blocks→md→blocks 후 보존', async () => {
+    const md = '> 링크\n>\n> - 범위\n> - 근거';
+    const blocks: any = await roundtrip(md);
+    expect(blocks[0].type).toBe('quote');
+    expect(blocks[0].content[0].text).toBe('링크');
+    expect(blocks[0].children.map((c: any) => c.type))
+      .toEqual(['bulletListItem', 'bulletListItem']);
+  });
+
+  it('중첩 리스트가 라운드트립 후 보존', async () => {
+    const blocks: any = await roundtrip('> - a\n>   - a1');
+    expect(blocks[0].children[0].children[0].type).toBe('bulletListItem');
+  });
+
+  it('코드펜스 내부 > 줄은 quote 로 변하지 않는다', async () => {
+    const editor = BlockNoteEditor.create({ schema });
+    const blocks: any = await parseMarkdownWithBlockquotes(editor, '```\n> x\n```');
+    expect(blocks[0].type).toBe('codeBlock');
   });
 });

--- a/frontend/src/markdown/blockquote.ts
+++ b/frontend/src/markdown/blockquote.ts
@@ -30,14 +30,14 @@ export function splitRuns(body: string): Run[] {
   return runs;
 }
 
-// 각 줄에서 blockquote 마커 1단계('>' + 공백 1개)만 제거한다.
+// 각 줄에서 blockquote 마커 1단계('>' + 공백 또는 탭 1개)만 제거한다.
 // 나머지 들여쓰기는 보존되어 중첩 리스트 구조가 유지된다.
 // '>' 단독 줄은 빈 줄이 된다. 중첩 blockquote('>>')는 1단계만 벗겨 내부 '>'가 남는다(의도적).
 export function stripQuotePrefix(text: string): string {
   return text
     .split('\n')
     .map(line => {
-      const m = line.match(/^ {0,3}>( ?)(.*)$/);
+      const m = line.match(/^ {0,3}>([ \t]?)(.*)$/);
       return m ? m[2] : line;
     })
     .join('\n');
@@ -60,7 +60,10 @@ export async function parseMarkdownWithBlockquotes(
   body: string,
 ): Promise<AnyBlock[]> {
   const out: AnyBlock[] = [];
-  for (const run of splitRuns(body)) {
+  // 에디터가 파일 원본 바이트를 그대로 넘기므로 CRLF/CR 줄바꿈을 LF 로 정규화한다.
+  // (정규화하지 않으면 stripQuotePrefix 의 '.' 가 \r 을 못 먹어 '>' 가 남는다)
+  const normalized = body.replace(/\r\n?/g, '\n');
+  for (const run of splitRuns(normalized)) {
     if (run.kind === 'plain') {
       if (run.text.trim() === '') continue; // 빈 분리 run은 빈 paragraph 주입을 피하려 건너뛴다
       const blocks = (await editor.tryParseMarkdownToBlocks(run.text)) as AnyBlock[];

--- a/frontend/src/markdown/blockquote.ts
+++ b/frontend/src/markdown/blockquote.ts
@@ -73,3 +73,48 @@ export async function parseMarkdownWithBlockquotes(
   }
   return out;
 }
+
+// 단일 quote 블록을 직렬화한다. lead(선행 단락)와 children(리스트)를 각각 BlockNote로
+// 직렬화한 뒤 children 모든 줄에 '> ' 접두사를 다시 입혀 합친다.
+async function serializeQuote(
+  editor: BlockNoteEditor<any, any, any>,
+  quote: AnyBlock,
+): Promise<string> {
+  const children = quote.children ?? [];
+  const hasContent = Array.isArray(quote.content) && quote.content.length > 0;
+  const lead = hasContent
+    ? (await editor.blocksToMarkdownLossy([{ ...quote, children: [] }] as any)).trimEnd()
+    : '';
+  if (children.length === 0) return lead || '>';
+  const childMd = (await editor.blocksToMarkdownLossy(children as any)).trimEnd();
+  const prefixed = childMd
+    .split('\n')
+    .map(l => (l.length ? `> ${l}` : '>'))
+    .join('\n');
+  return lead ? `${lead}\n>\n${prefixed}` : prefixed;
+}
+
+// 블록 트리를 마크다운으로 직렬화하되 quote 블록만 '>' 접두사 복원을 거친다.
+// 인접한 비-quote 블록은 묶어서 한 번에 BlockNote로 직렬화한다.
+export async function serializeBlocksWithBlockquotes(
+  editor: BlockNoteEditor<any, any, any>,
+  blocks: AnyBlock[],
+): Promise<string> {
+  const parts: string[] = [];
+  let buffer: AnyBlock[] = [];
+  const flush = async () => {
+    if (buffer.length === 0) return;
+    parts.push((await editor.blocksToMarkdownLossy(buffer as any)).trimEnd());
+    buffer = [];
+  };
+  for (const block of blocks) {
+    if (block.type === 'quote') {
+      await flush();
+      parts.push(await serializeQuote(editor, block));
+    } else {
+      buffer.push(block);
+    }
+  }
+  await flush();
+  return parts.join('\n\n') + '\n';
+}

--- a/frontend/src/markdown/blockquote.ts
+++ b/frontend/src/markdown/blockquote.ts
@@ -1,0 +1,25 @@
+export type Run = { kind: 'quote' | 'plain'; text: string };
+
+const QUOTE_LINE_RE = /^ {0,3}>/;
+const FENCE_RE = /^ {0,3}(```|~~~)/;
+
+// 원문을 줄 단위로 훑어 연속된 blockquote 줄 / 일반 줄 구간(run)으로 나눈다.
+// 코드펜스(``` 또는 ~~~) 내부의 '>' 줄은 blockquote로 오인하지 않는다.
+export function splitRuns(body: string): Run[] {
+  const lines = body.split('\n');
+  const runs: Run[] = [];
+  let cur: Run | null = null;
+  let inFence = false;
+
+  for (const line of lines) {
+    if (FENCE_RE.test(line)) inFence = !inFence;
+    const kind: Run['kind'] = !inFence && QUOTE_LINE_RE.test(line) ? 'quote' : 'plain';
+    if (!cur || cur.kind !== kind) {
+      cur = { kind, text: line };
+      runs.push(cur);
+    } else {
+      cur.text += '\n' + line;
+    }
+  }
+  return runs;
+}

--- a/frontend/src/markdown/blockquote.ts
+++ b/frontend/src/markdown/blockquote.ts
@@ -1,4 +1,10 @@
+import type { BlockNoteEditor } from '@blocknote/core';
+
 export type Run = { kind: 'quote' | 'plain'; text: string };
+
+type AnyBlock = { type: string; props?: Record<string, any>; content?: any; children?: AnyBlock[] };
+
+const QUOTE_PROPS = { backgroundColor: 'default', textColor: 'default' } as const;
 
 const QUOTE_LINE_RE = /^ {0,3}>/;
 const FENCE_RE = /^ {0,3}(```|~~~)/;
@@ -35,4 +41,35 @@ export function stripQuotePrefix(text: string): string {
       return m ? m[2] : line;
     })
     .join('\n');
+}
+
+// 벗긴 내부 블록 배열을 단일 quote 블록으로 조립한다.
+function assembleQuote(innerBlocks: AnyBlock[]): AnyBlock {
+  let content: any[] = [];
+  let children: AnyBlock[] = innerBlocks;
+  if (innerBlocks.length > 0 && innerBlocks[0].type === 'paragraph') {
+    content = (innerBlocks[0].content as any[]) ?? [];
+    children = innerBlocks.slice(1);
+  }
+  return { type: 'quote', props: { ...QUOTE_PROPS }, content, children };
+}
+
+// 원문 마크다운을 파싱하되 blockquote 구간은 '>'를 벗겨 BlockNote에 재위임 후 quote로 조립한다.
+export async function parseMarkdownWithBlockquotes(
+  editor: BlockNoteEditor<any, any, any>,
+  body: string,
+): Promise<AnyBlock[]> {
+  const out: AnyBlock[] = [];
+  for (const run of splitRuns(body)) {
+    if (run.kind === 'plain') {
+      if (run.text.trim() === '') continue; // 빈 분리 run은 빈 paragraph 주입을 피하려 건너뛴다
+      const blocks = (await editor.tryParseMarkdownToBlocks(run.text)) as AnyBlock[];
+      out.push(...blocks);
+    } else {
+      const inner = stripQuotePrefix(run.text);
+      const innerBlocks = (await editor.tryParseMarkdownToBlocks(inner)) as AnyBlock[];
+      out.push(assembleQuote(innerBlocks));
+    }
+  }
+  return out;
 }

--- a/frontend/src/markdown/blockquote.ts
+++ b/frontend/src/markdown/blockquote.ts
@@ -23,3 +23,16 @@ export function splitRuns(body: string): Run[] {
   }
   return runs;
 }
+
+// 각 줄에서 blockquote 마커 1단계('>' + 공백 1개)만 제거한다.
+// 나머지 들여쓰기는 보존되어 중첩 리스트 구조가 유지된다.
+// '>' 단독 줄은 빈 줄이 된다. 중첩 blockquote('>>')는 1단계만 벗겨 내부 '>'가 남는다(의도적).
+export function stripQuotePrefix(text: string): string {
+  return text
+    .split('\n')
+    .map(line => {
+      const m = line.match(/^ {0,3}>( ?)(.*)$/);
+      return m ? m[2] : line;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
## Summary
- blockquote 안의 bullet/numbered 리스트(중첩 포함)를 파싱·렌더·저장 가능하게 함
- 원인: BlockNote 0.49는 `>` 내부 리스트를 파싱 시 평탄화하고, 직렬화 시 quote children에서 `>` 접두사를 누락(blockquote 탈출). 0.51.4도 동일하게 미해결 확인
- 해법: 신규 모듈 `frontend/src/markdown/blockquote.ts`가 `>` 껍데기를 벗겨 BlockNote에 재위임(파싱)하고 다시 씌움(직렬화). 검증된 top-level 리스트 처리를 양방향 재활용
- `Editor.tsx` 로드/리로드/저장 경로 3곳을 새 함수로 교체
- `postParse`/`preSerialize`(KaTeX·Mermaid)와 합성: quote children 내부 수식/다이어그램도 양방향 보존

## 범위
- bullet + numbered 리스트, 선행 단락 + 리스트, 중첩 리스트 지원
- 중첩 blockquote(`>>`)는 의도적 미지원(1단계만 처리)

## 주요 구현
- `splitRuns`: 코드펜스 인지 라인 스캐너(펜스 내 `>` 오인 방지)
- `stripQuotePrefix`: `>` + 공백/탭 1개 제거, 중첩 들여쓰기 보존, CRLF 정규화
- `parseMarkdownWithBlockquotes` / `serializeBlocksWithBlockquotes`

## Test plan
- [x] `blockquote.test.ts` 19개 (파싱/직렬화/라운드트립/펜스/CRLF/tab) 통과
- [x] 전체 프론트엔드 테스트 212개 무회귀
- [x] `./gradlew buildFrontend` 성공
- [ ] runIde 육안 확인: blockquote+리스트 렌더 및 저장 라운드트립

## 설계/플랜 문서
- `docs/superpowers/specs/2026-06-11-blockquote-list-support-design.md`
- `docs/superpowers/plans/2026-06-11-blockquote-list-support.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)